### PR TITLE
Koblet inn SøknadMottakRiver så den faktisk lytter på rapiden.

### DIFF
--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/App.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/App.kt
@@ -3,6 +3,8 @@ package no.nav.tiltakspenger.vedtak
 import mu.KotlinLogging
 import no.nav.helse.rapids_rivers.RapidApplication
 import no.nav.helse.rapids_rivers.RapidsConnection
+import no.nav.tiltakspenger.vedtak.repository.InMemorySøkerRepository
+import no.nav.tiltakspenger.vedtak.rivers.SøknadMottakRiver
 import no.nav.tiltakspenger.vedtak.routes.TokenVerificationConfig
 import no.nav.tiltakspenger.vedtak.routes.vedtakApi
 
@@ -29,15 +31,15 @@ fun main() {
         .withKtorModule(vedtakApi(TokenVerificationConfig.fromEnv()))
         .build()
         .also {
-            /*
-            val søkerRepository = TODO()
+
+            val søkerRepository = InMemorySøkerRepository()
             val søkerMediator = SøkerMediator(
                 søkerRepository = søkerRepository,
                 rapidsConnection = it,
                 observatører = listOf()
             )
-            SøknadMottakTjeneste(søkerMediator = søkerMediator, rapidsConnection = it)
-            */
+            SøknadMottakRiver(søkerMediator = søkerMediator, rapidsConnection = it)
+
             TestService(it)
 
             Thread.sleep(5000)

--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/repository/InMemorySøkerRepository.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/repository/InMemorySøkerRepository.kt
@@ -1,6 +1,6 @@
-package no.nav.tiltakspenger.vedtak
+package no.nav.tiltakspenger.vedtak.repository
 
-import no.nav.tiltakspenger.vedtak.repository.SøkerRepository
+import no.nav.tiltakspenger.vedtak.Søker
 
 class InMemorySøkerRepository : SøkerRepository {
 

--- a/app/src/test/kotlin/no/nav/tiltakspenger/vedtak/rivers/SøknadMottakRiverTest.kt
+++ b/app/src/test/kotlin/no/nav/tiltakspenger/vedtak/rivers/SøknadMottakRiverTest.kt
@@ -1,8 +1,8 @@
 package no.nav.tiltakspenger.vedtak.rivers
 
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
-import no.nav.tiltakspenger.vedtak.InMemorySøkerRepository
 import no.nav.tiltakspenger.vedtak.SøkerMediator
+import no.nav.tiltakspenger.vedtak.repository.InMemorySøkerRepository
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 


### PR DESCRIPTION
 Enn så lenge bruker den bare en InMemorySøkerRepository, men det bør like fullt gjøre det mulig å teste en flyt
