### PR TITLE
B Fix Oppdatering av søknad skal ta hensyn til saksbehandler

### DIFF
--- a/domene/src/main/kotlin/no/nav/tiltakspenger/domene/behandling/BehandlingTilBeslutter.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/domene/behandling/BehandlingTilBeslutter.kt
@@ -1,6 +1,5 @@
 package no.nav.tiltakspenger.domene.behandling
 
-import no.nav.tiltakspenger.domene.saksopplysning.Kilde
 import no.nav.tiltakspenger.domene.saksopplysning.Saksopplysning
 import no.nav.tiltakspenger.domene.vilkår.Utfall
 import no.nav.tiltakspenger.domene.vilkår.Vilkår
@@ -131,7 +130,9 @@ sealed interface BehandlingTilBeslutter : Søknadsbehandling {
                 sakId = sakId,
                 søknader = søknader + søknad,
                 vurderingsperiode = vurderingsperiode,
-                saksopplysninger = saksopplysninger.filterNot { it.kilde == Kilde.SØKNAD } + lagFaktaAvSøknad(søknad),
+                saksopplysninger = lagFaktaAvSøknad(søknad).fold(saksopplysninger) { acc, saksopplysning ->
+                    acc.oppdaterSaksopplysninger(saksopplysning)
+                },
                 tiltak = tiltak,
                 saksbehandler = saksbehandler,
             ).vilkårsvurder()
@@ -192,7 +193,9 @@ sealed interface BehandlingTilBeslutter : Søknadsbehandling {
                 sakId = sakId,
                 søknader = søknader + søknad,
                 vurderingsperiode = vurderingsperiode,
-                saksopplysninger = saksopplysninger.filterNot { it.kilde == Kilde.SØKNAD } + lagFaktaAvSøknad(søknad),
+                saksopplysninger = lagFaktaAvSøknad(søknad).fold(saksopplysninger) { acc, saksopplysning ->
+                    acc.oppdaterSaksopplysninger(saksopplysning)
+                },
                 tiltak = tiltak,
                 saksbehandler = saksbehandler,
             ).vilkårsvurder()

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/domene/behandling/BehandlingVilkårsvurdert.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/domene/behandling/BehandlingVilkårsvurdert.kt
@@ -1,7 +1,6 @@
 package no.nav.tiltakspenger.domene.behandling
 
 import mu.KotlinLogging
-import no.nav.tiltakspenger.domene.saksopplysning.Kilde
 import no.nav.tiltakspenger.domene.saksopplysning.Saksopplysning
 import no.nav.tiltakspenger.domene.vilkår.Utfall
 import no.nav.tiltakspenger.domene.vilkår.Vilkår
@@ -136,7 +135,9 @@ sealed interface BehandlingVilkårsvurdert : Søknadsbehandling {
                 sakId = sakId,
                 søknader = søknader + søknad,
                 vurderingsperiode = vurderingsperiode,
-                saksopplysninger = saksopplysninger.filterNot { it.kilde == Kilde.SØKNAD } + lagFaktaAvSøknad(søknad),
+                saksopplysninger = lagFaktaAvSøknad(søknad).fold(saksopplysninger) { acc, saksopplysning ->
+                    acc.oppdaterSaksopplysninger(saksopplysning)
+                },
                 tiltak = tiltak,
                 saksbehandler = saksbehandler,
             ).vilkårsvurder()
@@ -219,7 +220,9 @@ sealed interface BehandlingVilkårsvurdert : Søknadsbehandling {
                 sakId = sakId,
                 søknader = søknader + søknad,
                 vurderingsperiode = vurderingsperiode,
-                saksopplysninger = saksopplysninger.filterNot { it.kilde == Kilde.SØKNAD } + lagFaktaAvSøknad(søknad),
+                saksopplysninger = lagFaktaAvSøknad(søknad).fold(saksopplysninger) { acc, saksopplysning ->
+                    acc.oppdaterSaksopplysninger(saksopplysning)
+                },
                 tiltak = tiltak,
                 saksbehandler = saksbehandler,
             ).vilkårsvurder()
@@ -275,7 +278,9 @@ sealed interface BehandlingVilkårsvurdert : Søknadsbehandling {
                 sakId = sakId,
                 søknader = søknader + søknad,
                 vurderingsperiode = vurderingsperiode,
-                saksopplysninger = saksopplysninger.filterNot { it.kilde == Kilde.SØKNAD } + lagFaktaAvSøknad(søknad),
+                saksopplysninger = lagFaktaAvSøknad(søknad).fold(saksopplysninger) { acc, saksopplysning ->
+                    acc.oppdaterSaksopplysninger(saksopplysning)
+                },
                 tiltak = tiltak,
                 saksbehandler = saksbehandler,
             ).vilkårsvurder()

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/domene/behandling/Søknadsbehandling.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/domene/behandling/Søknadsbehandling.kt
@@ -1,6 +1,5 @@
 package no.nav.tiltakspenger.domene.behandling
 
-import no.nav.tiltakspenger.domene.saksopplysning.Kilde
 import no.nav.tiltakspenger.domene.saksopplysning.Saksopplysning
 import no.nav.tiltakspenger.domene.saksopplysning.lagVurdering
 import no.nav.tiltakspenger.domene.vilkår.Utfall
@@ -152,7 +151,9 @@ sealed interface Søknadsbehandling : Behandling {
                 sakId = sakId,
                 søknader = søknader + søknad,
                 vurderingsperiode = vurderingsperiode,
-                saksopplysninger = saksopplysninger.filterNot { it.kilde == Kilde.SØKNAD } + lagFaktaAvSøknad(søknad),
+                saksopplysninger = lagFaktaAvSøknad(søknad).fold(saksopplysninger) { acc, saksopplysning ->
+                    acc.oppdaterSaksopplysninger(saksopplysning)
+                },
                 tiltak = tiltak,
                 saksbehandler = saksbehandler,
             ).vilkårsvurder()


### PR DESCRIPTION
Når en behandling ikke har blitt iverksatt enda, skal søker kunne sende inn ny søknad som erstatter den gamle.
De nye verdiene i søknaden skal erstatte de forrige, men hvis en saksbehandler har gjort endringer på et av vilkårene blir det litt spesielt. Da er det slik at hvis det aktuelle vilkåret i den forrige og den nye søknaden er like skal saksbehandler sin endring beholdes, men hvis vilkåret har endret seg fra forrige søknad skal saksbehandler sin endring fjernes.

Dette er en feil som ble oppdaget under testing av #577  https://trello.com/c/ylpe7eGC/577-ved-henting-av-saksopplysninger-m%C3%A5-vi-ikke-overskrive-de-gamle-hvis-de-ikke-har-endret-seg
