### PR TITLE
Lagt til SakDetaljer

### DIFF
--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/repository/sak/SakRepo.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/repository/sak/SakRepo.kt
@@ -1,6 +1,7 @@
 package no.nav.tiltakspenger.vedtak.repository.sak
 
 import no.nav.tiltakspenger.domene.sak.Sak
+import no.nav.tiltakspenger.domene.sak.SakDetaljer
 import no.nav.tiltakspenger.felles.Periode
 import no.nav.tiltakspenger.felles.SakId
 
@@ -9,6 +10,6 @@ interface SakRepo {
     fun lagre(sak: Sak): Sak
 
     fun hent(sakId: SakId): Sak?
-    fun hentKunSak(sakId: SakId): Sak?
+    fun hentSakDetaljer(sakId: SakId): SakDetaljer?
     fun hentForJournalpostId(journalpostId: String): Sak?
 }

--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/service/utbetaling/UtbetalingServiceImpl.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/service/utbetaling/UtbetalingServiceImpl.kt
@@ -15,7 +15,7 @@ class UtbetalingServiceImpl(
     }
 
     private fun mapUtbetalingReq(vedtak: Vedtak): UtbetalingDTO {
-        val sak = sakRepo.hentKunSak(vedtak.sakId) ?: throw IllegalStateException("Fant ikke sak for vedtak")
+        val sak = sakRepo.hentSakDetaljer(vedtak.sakId) ?: throw IllegalStateException("Fant ikke sak for vedtak")
         return UtbetalingDTO(
             sakId = sak.id.toString(),
             utløsendeId = vedtak.behandling.id.toString(),

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/domene/sak/Sak.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/domene/sak/Sak.kt
@@ -14,14 +14,11 @@ private val LOG = KotlinLogging.logger {}
 private val SECURELOG = KotlinLogging.logger("tjenestekall")
 
 data class Sak(
-    val id: SakId,
-    val ident: String,
-    val saknummer: Saksnummer,
-    val periode: Periode,
+    val sakDetaljer: SakDetaljer,
     val behandlinger: List<Behandling>,
     val personopplysninger: List<Personopplysninger>,
     val vedtak: List<Vedtak>,
-) {
+) : SakDetaljer by sakDetaljer {
     fun håndter(søknad: Søknad): Sak {
         val iverksatteBehandlinger = behandlinger.filterIsInstance<BehandlingIverksatt>()
         val behandlinger = behandlinger
@@ -46,13 +43,36 @@ data class Sak(
     }
 
     companion object {
+        operator fun invoke(
+            id: SakId,
+            ident: String,
+            saknummer: Saksnummer,
+            periode: Periode,
+            behandlinger: List<Behandling>,
+            personopplysninger: List<Personopplysninger>,
+            vedtak: List<Vedtak>,
+        ): Sak =
+            Sak(
+                sakDetaljer = TynnSak(
+                    id = id,
+                    ident = ident,
+                    saknummer = saknummer,
+                    periode = periode,
+                ),
+                behandlinger = behandlinger,
+                personopplysninger = personopplysninger,
+                vedtak = vedtak,
+            )
+
         fun lagSak(søknad: Søknad, saksnummerGenerator: SaksnummerGenerator): Sak {
             return Sak(
-                id = SakId.random(),
-                ident = søknad.personopplysninger.ident,
-                saknummer = saksnummerGenerator.genererSaknummer(),
+                sakDetaljer = TynnSak(
+                    id = SakId.random(),
+                    ident = søknad.personopplysninger.ident,
+                    saknummer = saksnummerGenerator.genererSaknummer(),
+                    periode = søknad.vurderingsperiode(),
+                ),
                 behandlinger = emptyList(),
-                periode = søknad.vurderingsperiode(),
                 personopplysninger = emptyList(),
                 vedtak = emptyList(),
             )

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/domene/sak/TynnSak.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/domene/sak/TynnSak.kt
@@ -1,0 +1,18 @@
+package no.nav.tiltakspenger.domene.sak
+
+import no.nav.tiltakspenger.felles.Periode
+import no.nav.tiltakspenger.felles.SakId
+
+interface SakDetaljer {
+    val id: SakId
+    val ident: String
+    val saknummer: Saksnummer
+    val periode: Periode
+}
+
+data class TynnSak(
+    override val id: SakId,
+    override val ident: String,
+    override val saknummer: Saksnummer,
+    override val periode: Periode,
+) : SakDetaljer


### PR DESCRIPTION
Lagt til SakDetaljer som et interface som representerer Sak uten underliggende lister, og TynnSak som er en klasse som implementerer SakDetaljer. Sak implementerer også SakDetaljer, men Sak bruker TynnSak vha delegation i implementasjonen. Dette er ikke egentlig synlig utenfor Sak, TynnSak er gjemt bort vha delegation og en factory metode i companion object.

SakRepo::hentKunSak(sakId: SakId): Sak? 
med emptyLister i Sak er endret til å være 
SakRepo::hentSakDetaljer(sakId: SakId): SakDetaljer?
Denne brukes pt bare fra UtbetalingServiceImpl