### PR TITLE
Fjernet innerste sealed class laget i behandling

### DIFF
--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/repository/behandling/PostgresBehandlingRepo.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/repository/behandling/PostgresBehandlingRepo.kt
@@ -6,6 +6,7 @@ import kotliquery.queryOf
 import kotliquery.sessionOf
 import mu.KotlinLogging
 import no.nav.tiltakspenger.domene.behandling.BehandlingIverksatt
+import no.nav.tiltakspenger.domene.behandling.BehandlingStatus
 import no.nav.tiltakspenger.domene.behandling.BehandlingTilBeslutter
 import no.nav.tiltakspenger.domene.behandling.BehandlingVilkårsvurdert
 import no.nav.tiltakspenger.domene.behandling.Søknadsbehandling
@@ -279,16 +280,17 @@ internal class PostgresBehandlingRepo(
             is BehandlingIverksatt -> "Iverksatt"
         }
 
-    private fun finnStatus(behandling: Søknadsbehandling) =
-        when (behandling) {
-            is Søknadsbehandling.Opprettet -> "Opprettet"
-            is BehandlingVilkårsvurdert.Avslag -> "Avslag"
-            is BehandlingVilkårsvurdert.Innvilget -> "Innvilget"
-            is BehandlingVilkårsvurdert.Manuell -> "Manuell"
-            is BehandlingIverksatt.Avslag -> "Avslag"
-            is BehandlingIverksatt.Innvilget -> "Innvilget"
-            is BehandlingTilBeslutter.Avslag -> "Avslag"
-            is BehandlingTilBeslutter.Innvilget -> "Innvilget"
+    private fun finnStatus(behandling: Søknadsbehandling): String =
+        when {
+            behandling is Søknadsbehandling.Opprettet -> "Opprettet"
+            behandling is BehandlingVilkårsvurdert && behandling.status == BehandlingStatus.Avslag -> "Avslag"
+            behandling is BehandlingVilkårsvurdert && behandling.status == BehandlingStatus.Innvilget -> "Innvilget"
+            behandling is BehandlingVilkårsvurdert && behandling.status == BehandlingStatus.Manuell -> "Manuell"
+            behandling is BehandlingIverksatt && behandling.status == BehandlingStatus.Avslag -> "Avslag"
+            behandling is BehandlingIverksatt && behandling.status == BehandlingStatus.Innvilget -> "Innvilget"
+            behandling is BehandlingTilBeslutter && behandling.status == BehandlingStatus.Avslag -> "Avslag"
+            behandling is BehandlingTilBeslutter && behandling.status == BehandlingStatus.Innvilget -> "Innvilget"
+            else -> throw IllegalStateException("Finner ikke status")
         }
 
     private val sqlHentSistEndret = """

--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/routes/behandling/SammenstillingForBehandlingDTO.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/routes/behandling/SammenstillingForBehandlingDTO.kt
@@ -4,6 +4,7 @@ import no.nav.tiltakspenger.domene.attestering.Attestering
 import no.nav.tiltakspenger.domene.attestering.AttesteringStatus
 import no.nav.tiltakspenger.domene.behandling.Behandling
 import no.nav.tiltakspenger.domene.behandling.BehandlingIverksatt
+import no.nav.tiltakspenger.domene.behandling.BehandlingStatus
 import no.nav.tiltakspenger.domene.behandling.BehandlingTilBeslutter
 import no.nav.tiltakspenger.domene.behandling.BehandlingVilkårsvurdert
 import no.nav.tiltakspenger.domene.behandling.Søknadsbehandling
@@ -360,10 +361,9 @@ enum class Kategori(val tittel: String, val vilkår: List<Vilkår>) {
     INSTITUSJONSOPPHOLD("Institusjonsopphold", listOf(Vilkår.INSTITUSJONSOPPHOLD)),
 }
 
-fun finnStatus(behandling: Søknadsbehandling) =
+fun finnStatus(behandling: Søknadsbehandling): String =
     when (behandling) {
-        is BehandlingIverksatt.Avslag -> "Iverksatt Avslag"
-        is BehandlingIverksatt.Innvilget -> "Iverksatt Innvilget"
+        is BehandlingIverksatt -> if (behandling.status == BehandlingStatus.Avslag) "Iverksatt Avslag" else "Iverksatt Innvilget"
         is BehandlingTilBeslutter -> if (behandling.beslutter == null) "Klar til beslutning" else "Under beslutning"
         is BehandlingVilkårsvurdert -> if (behandling.saksbehandler == null) "Klar til behandling" else "Under behandling"
         is Søknadsbehandling.Opprettet -> "Klar til behandling"

--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/service/vedtak/VedtakServiceImpl.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/service/vedtak/VedtakServiceImpl.kt
@@ -4,6 +4,7 @@ import kotliquery.TransactionalSession
 import mu.KotlinLogging
 import no.nav.helse.rapids_rivers.RapidsConnection
 import no.nav.tiltakspenger.domene.behandling.BehandlingIverksatt
+import no.nav.tiltakspenger.domene.behandling.BehandlingStatus
 import no.nav.tiltakspenger.domene.personopplysninger.søker
 import no.nav.tiltakspenger.domene.vedtak.Vedtak
 import no.nav.tiltakspenger.domene.vedtak.VedtaksType
@@ -38,11 +39,11 @@ class VedtakServiceImpl(
             sakId = behandling.sakId,
             behandling = behandling,
             vedtaksdato = LocalDateTime.now(),
-            vedtaksType = if (behandling is BehandlingIverksatt.Innvilget) VedtaksType.INNVILGELSE else VedtaksType.AVSLAG,
+            vedtaksType = if (behandling.status == BehandlingStatus.Innvilget) VedtaksType.INNVILGELSE else VedtaksType.AVSLAG,
             periode = behandling.vurderingsperiode,
             saksopplysninger = behandling.saksopplysninger(),
             vurderinger = behandling.vilkårsvurderinger,
-            saksbehandler = behandling.saksbehandler!!,
+            saksbehandler = behandling.saksbehandler,
             beslutter = behandling.beslutter,
         )
 

--- a/common/src/main/kotlin/no/nav/tiltakspenger/objectmothers/BehandlingMother.kt
+++ b/common/src/main/kotlin/no/nav/tiltakspenger/objectmothers/BehandlingMother.kt
@@ -22,12 +22,11 @@ interface BehandlingMother {
         periode: Periode = Periode(1.januar(2023), 31.mars(2023)),
         sakId: SakId = SakId.random(),
         søknad: Søknad = ObjectMother.nySøknad(periode = periode),
-    ): Søknadsbehandling.Opprettet {
-        return Søknadsbehandling.Opprettet.opprettBehandling(
+    ): Søknadsbehandling.Opprettet =
+        Søknadsbehandling.Opprettet.opprettBehandling(
             sakId = sakId,
             søknad = søknad,
         )
-    }
 
     fun saksopplysning(
         fom: LocalDate = 1.januar(2023),
@@ -36,7 +35,7 @@ interface BehandlingMother {
         vilkår: Vilkår = Vilkår.AAP,
         type: TypeSaksopplysning = TypeSaksopplysning.HAR_YTELSE,
         saksbehandler: String? = null,
-    ) =
+    ): Saksopplysning =
         Saksopplysning(
             fom = fom,
             tom = tom,
@@ -51,7 +50,7 @@ interface BehandlingMother {
         periode: Periode = Periode(1.januar(2023), 31.mars(2023)),
         sakId: SakId = SakId.random(),
         søknad: Søknad = ObjectMother.nySøknad(periode = periode),
-    ): BehandlingVilkårsvurdert.Innvilget {
+    ): BehandlingVilkårsvurdert {
         val behandling = vilkårViHenter().fold(behandling(periode, sakId, søknad)) { b: Søknadsbehandling, vilkår ->
             b.leggTilSaksopplysning(
                 saksopplysning(
@@ -61,36 +60,29 @@ interface BehandlingMother {
             ).behandling
         } as BehandlingVilkårsvurdert
 
-        return behandling.vurderPåNytt() as BehandlingVilkårsvurdert.Innvilget
+        return behandling.vurderPåNytt()
     }
 
     fun behandlingVilkårsvurdertAvslag(
         periode: Periode = Periode(1.januar(2023), 31.mars(2023)),
         sakId: SakId = SakId.random(),
         søknad: Søknad = ObjectMother.nySøknad(periode = periode),
-    ): BehandlingVilkårsvurdert.Avslag {
+    ): BehandlingVilkårsvurdert {
         val behandling = behandlingVilkårsvurdertInnvilget().leggTilSaksopplysning(
             saksopplysning(vilkår = Vilkår.KVP, type = TypeSaksopplysning.HAR_YTELSE),
         ).behandling as BehandlingVilkårsvurdert
 
-        return behandling.vurderPåNytt() as BehandlingVilkårsvurdert.Avslag
+        return behandling.vurderPåNytt()
     }
 
-    fun behandlingTilBeslutterInnvilget(): BehandlingTilBeslutter.Innvilget {
-        return behandlingVilkårsvurdertInnvilget().copy(
-            saksbehandler = "123",
-        ).tilBeslutting()
-    }
+    fun behandlingTilBeslutterInnvilget(): BehandlingTilBeslutter =
+        behandlingVilkårsvurdertInnvilget().copy(saksbehandler = "123").tilBeslutting()
 
-    fun behandlingTilBeslutterAvslag(): BehandlingTilBeslutter.Avslag {
-        return behandlingVilkårsvurdertAvslag().copy(
-            saksbehandler = "123",
-        ).tilBeslutting()
-    }
+    fun behandlingTilBeslutterAvslag(): BehandlingTilBeslutter =
+        behandlingVilkårsvurdertAvslag().copy(saksbehandler = "123").tilBeslutting()
 
-    fun behandlingInnvilgetIverksatt(): BehandlingIverksatt.Innvilget {
-        return behandlingTilBeslutterInnvilget().copy(beslutter = "beslutter").iverksett()
-    }
+    fun behandlingInnvilgetIverksatt(): BehandlingIverksatt =
+        behandlingTilBeslutterInnvilget().copy(beslutter = "beslutter").iverksett()
 
     fun vilkårViHenter() = listOf(
         Vilkår.AAP,
@@ -141,7 +133,7 @@ interface BehandlingMother {
         typeNavn: String = "Gruppe AMO",
         typeKode: String = "GRUPPEAMO",
         rettPåTiltakspenger: Boolean = true,
-    ) =
+    ): Tiltak.Gjennomføring =
         Tiltak.Gjennomføring(
             id = id,
             arrangørnavn = arrangørnavn,

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/domene/behandling/BehandlingStatus.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/domene/behandling/BehandlingStatus.kt
@@ -1,0 +1,6 @@
+package no.nav.tiltakspenger.domene.behandling
+
+// TODO: Burde egentlig ha en status per steg
+enum class BehandlingStatus {
+    Innvilget, Manuell, Avslag,
+}

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/domene/behandling/BehandlingTilBeslutter.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/domene/behandling/BehandlingTilBeslutter.kt
@@ -7,19 +7,87 @@ import no.nav.tiltakspenger.felles.BehandlingId
 import no.nav.tiltakspenger.felles.Periode
 import no.nav.tiltakspenger.felles.SakId
 
-sealed interface BehandlingTilBeslutter : Søknadsbehandling {
-    val vilkårsvurderinger: List<Vurdering>
-    val beslutter: String?
+data class BehandlingTilBeslutter(
+    override val id: BehandlingId,
+    override val sakId: SakId,
+    override val søknader: List<Søknad>,
+    override val vurderingsperiode: Periode,
+    override val saksopplysninger: List<Saksopplysning>,
+    override val tiltak: List<Tiltak>,
+    override val saksbehandler: String,
+    val vilkårsvurderinger: List<Vurdering>,
+    val beslutter: String?,
+    val status: BehandlingStatus,
+) : Søknadsbehandling {
 
     override fun søknad(): Søknad {
         return søknader.siste()
     }
 
-    fun iverksett(): BehandlingIverksatt
+    override fun erTilBeslutter() = true
 
-    fun sendTilbake(): BehandlingVilkårsvurdert
+    fun iverksett(): BehandlingIverksatt {
+        checkNotNull(beslutter) { "Ikke lov å iverksette uten beslutter" }
+        return when (status) {
+            BehandlingStatus.Manuell -> throw IllegalStateException("En behandling til beslutter kan ikke være manuell")
+            BehandlingStatus.Avslag -> throw IllegalStateException("Iverksett av Avslag fungerer, men skal ikke tillates i mvp 1 ${this.id}")
+            else -> BehandlingIverksatt(
+                id = id,
+                sakId = sakId,
+                søknader = søknader,
+                vurderingsperiode = vurderingsperiode,
+                saksopplysninger = saksopplysninger,
+                tiltak = tiltak,
+                vilkårsvurderinger = vilkårsvurderinger,
+                saksbehandler = saksbehandler,
+                beslutter = beslutter,
+                status = status,
+            )
+        }
+    }
 
-    fun vurderPåNytt(): BehandlingVilkårsvurdert {
+    fun sendTilbake(): BehandlingVilkårsvurdert {
+        return BehandlingVilkårsvurdert(
+            id = id,
+            sakId = sakId,
+            søknader = søknader,
+            vurderingsperiode = vurderingsperiode,
+            saksopplysninger = saksopplysninger,
+            tiltak = tiltak,
+            vilkårsvurderinger = vilkårsvurderinger,
+            saksbehandler = saksbehandler,
+            status = BehandlingStatus.Innvilget,
+        )
+    }
+
+    override fun leggTilSøknad(søknad: Søknad): BehandlingVilkårsvurdert {
+        return Søknadsbehandling.Opprettet.leggTilSøknad(
+            behandling = this,
+            søknad = søknad,
+        ).vilkårsvurder()
+    }
+
+    override fun leggTilSaksopplysning(saksopplysning: Saksopplysning): LeggTilSaksopplysningRespons {
+        val oppdatertSaksopplysningListe = saksopplysninger.oppdaterSaksopplysninger(saksopplysning)
+        return if (oppdatertSaksopplysningListe == this.saksopplysninger) {
+            LeggTilSaksopplysningRespons(
+                behandling = this,
+                erEndret = false,
+            )
+        } else {
+            LeggTilSaksopplysningRespons(
+                behandling = this.copy(saksopplysninger = oppdatertSaksopplysningListe).vurderPåNytt(),
+                erEndret = true,
+            )
+        }
+    }
+
+    override fun startBehandling(saksbehandler: String): Søknadsbehandling =
+        this.copy(
+            beslutter = saksbehandler,
+        )
+
+    private fun vurderPåNytt(): BehandlingVilkårsvurdert {
         return Søknadsbehandling.Opprettet(
             id = id,
             sakId = sakId,
@@ -44,50 +112,12 @@ sealed interface BehandlingTilBeslutter : Søknadsbehandling {
             saksbehandler: String,
             beslutter: String?,
         ): BehandlingTilBeslutter {
-            when (status) {
-                "Innvilget" -> return Innvilget(
-                    id = id,
-                    sakId = sakId,
-                    søknader = søknader,
-                    vurderingsperiode = vurderingsperiode,
-                    saksopplysninger = saksopplysninger,
-                    tiltak = tiltak,
-                    vilkårsvurderinger = vilkårsvurderinger,
-                    saksbehandler = saksbehandler,
-                    beslutter = beslutter,
-                )
-
-                "Avslag" -> return Avslag(
-                    id = id,
-                    sakId = sakId,
-                    søknader = søknader,
-                    vurderingsperiode = vurderingsperiode,
-                    saksopplysninger = saksopplysninger,
-                    tiltak = tiltak,
-                    vilkårsvurderinger = vilkårsvurderinger,
-                    saksbehandler = saksbehandler,
-                    beslutter = beslutter,
-                )
-
+            val behandlingStatus = when (status) {
+                "Innvilget" -> BehandlingStatus.Innvilget
+                "Avslag" -> BehandlingStatus.Avslag
                 else -> throw IllegalStateException("Ukjent BehandlingTilBeslutting $id med status $status")
             }
-        }
-    }
-
-    data class Innvilget(
-        override val id: BehandlingId,
-        override val sakId: SakId,
-        override val søknader: List<Søknad>,
-        override val vurderingsperiode: Periode,
-        override val saksopplysninger: List<Saksopplysning>,
-        override val tiltak: List<Tiltak>,
-        override val vilkårsvurderinger: List<Vurdering>,
-        override val saksbehandler: String,
-        override val beslutter: String?,
-    ) : BehandlingTilBeslutter {
-        override fun iverksett(): BehandlingIverksatt.Innvilget {
-            checkNotNull(beslutter) { "Ikke lov å iverksette uten beslutter" }
-            return BehandlingIverksatt.Innvilget(
+            return BehandlingTilBeslutter(
                 id = id,
                 sakId = sakId,
                 søknader = søknader,
@@ -97,118 +127,8 @@ sealed interface BehandlingTilBeslutter : Søknadsbehandling {
                 vilkårsvurderinger = vilkårsvurderinger,
                 saksbehandler = saksbehandler,
                 beslutter = beslutter,
+                status = behandlingStatus,
             )
         }
-
-        override fun erTilBeslutter() = true
-
-        override fun sendTilbake(): BehandlingVilkårsvurdert.Innvilget {
-            return BehandlingVilkårsvurdert.Innvilget(
-                id = id,
-                sakId = sakId,
-                søknader = søknader,
-                vurderingsperiode = vurderingsperiode,
-                saksopplysninger = saksopplysninger,
-                tiltak = tiltak,
-                vilkårsvurderinger = vilkårsvurderinger,
-                saksbehandler = saksbehandler,
-            )
-        }
-
-        override fun leggTilSøknad(søknad: Søknad): BehandlingVilkårsvurdert {
-            return Søknadsbehandling.Opprettet.leggTilSøknad(
-                behandling = this,
-                søknad = søknad,
-            ).vilkårsvurder()
-        }
-
-        override fun leggTilSaksopplysning(saksopplysning: Saksopplysning): LeggTilSaksopplysningRespons {
-            val oppdatertSaksopplysningListe = saksopplysninger.oppdaterSaksopplysninger(saksopplysning)
-            return if (oppdatertSaksopplysningListe == this.saksopplysninger) {
-                LeggTilSaksopplysningRespons(
-                    behandling = this,
-                    erEndret = false,
-                )
-            } else {
-                LeggTilSaksopplysningRespons(
-                    behandling = this.copy(saksopplysninger = oppdatertSaksopplysningListe).vurderPåNytt(),
-                    erEndret = true,
-                )
-            }
-        }
-
-        override fun startBehandling(saksbehandler: String): Søknadsbehandling =
-            this.copy(
-                beslutter = saksbehandler,
-            )
-    }
-
-    data class Avslag(
-        override val id: BehandlingId,
-        override val sakId: SakId,
-        override val søknader: List<Søknad>,
-        override val vurderingsperiode: Periode,
-        override val saksopplysninger: List<Saksopplysning>,
-        override val tiltak: List<Tiltak>,
-        override val vilkårsvurderinger: List<Vurdering>,
-        override val saksbehandler: String,
-        override val beslutter: String?,
-    ) : BehandlingTilBeslutter {
-        override fun iverksett(): BehandlingIverksatt.Avslag {
-            checkNotNull(beslutter) { "Ikke lov å iverksette uten beslutter" }
-            return BehandlingIverksatt.Avslag(
-                id = id,
-                sakId = sakId,
-                søknader = søknader,
-                vurderingsperiode = vurderingsperiode,
-                saksopplysninger = saksopplysninger,
-                tiltak = tiltak,
-                vilkårsvurderinger = vilkårsvurderinger,
-                saksbehandler = saksbehandler,
-                beslutter = beslutter,
-            )
-        }
-
-        override fun erTilBeslutter() = true
-
-        override fun leggTilSøknad(søknad: Søknad): BehandlingVilkårsvurdert {
-            return Søknadsbehandling.Opprettet.leggTilSøknad(
-                behandling = this,
-                søknad = søknad,
-            ).vilkårsvurder()
-        }
-
-        override fun sendTilbake(): BehandlingVilkårsvurdert.Avslag {
-            return BehandlingVilkårsvurdert.Avslag(
-                id = id,
-                sakId = sakId,
-                søknader = søknader,
-                vurderingsperiode = vurderingsperiode,
-                saksopplysninger = saksopplysninger,
-                tiltak = tiltak,
-                vilkårsvurderinger = vilkårsvurderinger,
-                saksbehandler = saksbehandler,
-            )
-        }
-
-        override fun leggTilSaksopplysning(saksopplysning: Saksopplysning): LeggTilSaksopplysningRespons {
-            val oppdatertSaksopplysningListe = saksopplysninger.oppdaterSaksopplysninger(saksopplysning)
-            return if (oppdatertSaksopplysningListe == this.saksopplysninger) {
-                LeggTilSaksopplysningRespons(
-                    behandling = this,
-                    erEndret = false,
-                )
-            } else {
-                LeggTilSaksopplysningRespons(
-                    behandling = this.copy(saksopplysninger = oppdatertSaksopplysningListe).vurderPåNytt(),
-                    erEndret = true,
-                )
-            }
-        }
-
-        override fun startBehandling(saksbehandler: String): Søknadsbehandling =
-            this.copy(
-                beslutter = saksbehandler,
-            )
     }
 }

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/domene/behandling/Søknadsbehandling.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/domene/behandling/Søknadsbehandling.kt
@@ -93,55 +93,23 @@ sealed interface Søknadsbehandling : Behandling {
             }
 
             // Etter at vi har laget vurderinger, sjekker vi utfallet
-            return when {
-                vurderinger.any { it.utfall == Utfall.KREVER_MANUELL_VURDERING } ->
-                    BehandlingVilkårsvurdert.Manuell(
-                        id = id,
-                        sakId = sakId,
-                        søknader = søknader,
-                        vurderingsperiode = vurderingsperiode,
-                        saksopplysninger = saksopplysninger,
-                        tiltak = tiltak,
-                        vilkårsvurderinger = vurderinger,
-                        saksbehandler = saksbehandler,
-                    )
-
-                vurderinger.all { it.utfall == Utfall.OPPFYLT } ->
-                    BehandlingVilkårsvurdert.Innvilget(
-                        id = id,
-                        sakId = sakId,
-                        søknader = søknader,
-                        vurderingsperiode = vurderingsperiode,
-                        saksopplysninger = saksopplysninger,
-                        tiltak = tiltak,
-                        vilkårsvurderinger = vurderinger,
-                        saksbehandler = saksbehandler,
-                    )
-
-                vurderinger.all { it.utfall == Utfall.IKKE_OPPFYLT } ->
-                    BehandlingVilkårsvurdert.Avslag(
-                        id = id,
-                        sakId = sakId,
-                        søknader = søknader,
-                        vurderingsperiode = vurderingsperiode,
-                        saksopplysninger = saksopplysninger,
-                        tiltak = tiltak,
-                        vilkårsvurderinger = vurderinger,
-                        saksbehandler = saksbehandler,
-                    )
-
-                else ->
-                    BehandlingVilkårsvurdert.Avslag(
-                        id = id,
-                        sakId = sakId,
-                        søknader = søknader,
-                        vurderingsperiode = vurderingsperiode,
-                        saksopplysninger = saksopplysninger,
-                        tiltak = tiltak,
-                        vilkårsvurderinger = vurderinger,
-                        saksbehandler = saksbehandler,
-                    )
+            val status = when {
+                vurderinger.any { it.utfall == Utfall.KREVER_MANUELL_VURDERING } -> BehandlingStatus.Manuell
+                vurderinger.all { it.utfall == Utfall.OPPFYLT } -> BehandlingStatus.Innvilget
+                vurderinger.all { it.utfall == Utfall.IKKE_OPPFYLT } -> BehandlingStatus.Avslag
+                else -> BehandlingStatus.Avslag
             }
+            return BehandlingVilkårsvurdert(
+                id = id,
+                sakId = sakId,
+                søknader = søknader,
+                vurderingsperiode = vurderingsperiode,
+                saksopplysninger = saksopplysninger,
+                tiltak = tiltak,
+                vilkårsvurderinger = vurderinger,
+                saksbehandler = saksbehandler,
+                status = status,
+            )
         }
 
         // TODO: Hva er forskjellen på denne og på leggTilSøknad (og opprettBehandling) lenger opp?


### PR DESCRIPTION
Dette er kanskje kontroversielt, men jeg synes koden ble enklere å både lese, skrive og forstå av å fjerne det innerste laget med sealed classes i Behandling. Vi hadde ulike klasser per status (innvilget, avslag, manuell), men det var bare statusen som varierte. Det meste annet var likt. Jeg forstår ikke at dette er en god bruk av sealed classes, så jeg flata ut hierarkiet litt.

Diffen er vanskelig å lese, så jeg anbefaler å pulle ned branchen.

NB. Jeg baserte meg på forrige PR da jeg gjorde dette, hvor jeg skrev om litt rundt Saksopplysning. Så de endringene er også med her. Sorry, men det gjorde alt så mye lettere..