### PR TITLE
D Skrevet enhetstester til SammenstillingForBehandlingDTO

### DIFF
--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/routes/behandling/SammenstillingForBehandlingDTO.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/routes/behandling/SammenstillingForBehandlingDTO.kt
@@ -93,6 +93,13 @@ data class FaktaDTO(
     val harIkkeYtelse: String,
 )
 
+fun settBeslutter(behandling: Søknadsbehandling): String? =
+    when (behandling) {
+        is BehandlingIverksatt -> behandling.beslutter
+        is BehandlingTilBeslutter -> behandling.beslutter
+        else -> null
+    }
+
 fun mapSammenstillingDTO(
     behandling: Søknadsbehandling,
     personopplysninger: List<Personopplysninger>,
@@ -101,11 +108,7 @@ fun mapSammenstillingDTO(
     return SammenstillingForBehandlingDTO(
         behandlingId = behandling.id.toString(),
         saksbehandler = behandling.saksbehandler,
-        beslutter = when (behandling) {
-            is BehandlingIverksatt -> behandling.beslutter
-            is BehandlingTilBeslutter -> behandling.beslutter
-            else -> null
-        },
+        beslutter = settBeslutter(behandling),
         fom = behandling.vurderingsperiode.fra,
         tom = behandling.vurderingsperiode.til,
         søknad = SøknadDTO(
@@ -162,6 +165,7 @@ fun mapSammenstillingDTO(
             )
         }.first(),
         tilstand = when (behandling) {
+            // todo: dette kunne kanskje vært en egen "tilstand"-property på de ulike behandlingstypene?
             is BehandlingIverksatt -> "iverksatt"
             is BehandlingTilBeslutter -> "tilBeslutter"
             is BehandlingVilkårsvurdert -> "vilkårsvurdert"
@@ -213,7 +217,7 @@ fun settUtfall(behandling: Behandling, saksopplysning: Saksopplysning): String {
     }
 }
 
-private fun hentUtfallForVilkår(vilkår: Vilkår, vurderinger: List<Vurdering>): Utfall {
+fun hentUtfallForVilkår(vilkår: Vilkår, vurderinger: List<Vurdering>): Utfall {
     if (vurderinger.any { it.vilkår == vilkår && it.utfall == Utfall.KREVER_MANUELL_VURDERING }) return Utfall.KREVER_MANUELL_VURDERING
     if (vurderinger.any { it.vilkår == vilkår && it.utfall == Utfall.IKKE_OPPFYLT }) return Utfall.IKKE_OPPFYLT
     if (vurderinger.filter { it.vilkår == vilkår }.all { it.utfall == Utfall.OPPFYLT }) return Utfall.OPPFYLT

--- a/app/src/test/kotlin/no/nav/tiltakspenger/vedtak/routes/behandling/SammenstillingForBehandlingDTOTest.kt
+++ b/app/src/test/kotlin/no/nav/tiltakspenger/vedtak/routes/behandling/SammenstillingForBehandlingDTOTest.kt
@@ -1,0 +1,203 @@
+package no.nav.tiltakspenger.vedtak.routes.behandling
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.tiltakspenger.domene.behandling.BehandlingIverksatt
+import no.nav.tiltakspenger.domene.behandling.BehandlingTilBeslutter
+import no.nav.tiltakspenger.domene.behandling.BehandlingVilkårsvurdert
+import no.nav.tiltakspenger.domene.behandling.Søknadsbehandling
+import no.nav.tiltakspenger.domene.saksopplysning.Kilde
+import no.nav.tiltakspenger.domene.saksopplysning.Saksopplysning
+import no.nav.tiltakspenger.domene.saksopplysning.TypeSaksopplysning
+import no.nav.tiltakspenger.domene.vilkår.Utfall
+import no.nav.tiltakspenger.domene.vilkår.Vilkår
+import no.nav.tiltakspenger.domene.vilkår.Vurdering
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class SammenstillingForBehandlingDTOTest {
+
+    @Test
+    fun `finnStatus skal gi riktig statustekst basert på behandlingen`() {
+        val avslåttBehandling = mockk<BehandlingIverksatt.Avslag>()
+        val avslagStatus = finnStatus(avslåttBehandling)
+        assert(avslagStatus === "Iverksatt Avslag")
+
+        val innvilgetBehandling = mockk<BehandlingIverksatt.Innvilget>()
+        val innvilgetStatus = finnStatus(innvilgetBehandling)
+        assert(innvilgetStatus === "Iverksatt Innvilget")
+
+        val opprettetBehandling = mockk<Søknadsbehandling.Opprettet>()
+        val opprettetStatus = finnStatus(opprettetBehandling)
+        assert(opprettetStatus === "Klar til behandling")
+    }
+
+    @Test
+    fun `finnStatus skal gi riktig statustekst når behandlingen er sendt til beslutter`() {
+        val behandlingTilBeslutter = mockk<BehandlingTilBeslutter.Innvilget>()
+        every { behandlingTilBeslutter.beslutter } returns null
+        val klarTilBeslutningTekst = finnStatus(behandlingTilBeslutter)
+        assert(klarTilBeslutningTekst === "Klar til beslutning")
+
+        every { behandlingTilBeslutter.beslutter } returns "test beslutter"
+        val underBeslutningTekst = finnStatus(behandlingTilBeslutter)
+        assert(underBeslutningTekst === "Under beslutning")
+    }
+
+    @Test
+    fun `finnStatus skal gi riktig statustekst når behandlingen er ferdig vilkårsvurdert`() {
+        val behandlingVilkårsvurdert = mockk<BehandlingVilkårsvurdert.Innvilget>()
+        every { behandlingVilkårsvurdert.saksbehandler } returns null
+        val klarTilBeslutningTekst = finnStatus(behandlingVilkårsvurdert)
+        assert(klarTilBeslutningTekst === "Klar til behandling")
+
+        every { behandlingVilkårsvurdert.saksbehandler } returns "test saksbehandler"
+        val underBeslutningTekst = finnStatus(behandlingVilkårsvurdert)
+        assert(underBeslutningTekst === "Under behandling")
+    }
+
+    private fun mockKreverManuellVurdering(vilkår: Vilkår = Vilkår.AAP): Vurdering.KreverManuellVurdering = Vurdering.KreverManuellVurdering(
+        vilkår = vilkår,
+        fom = LocalDate.now(),
+        tom = LocalDate.now(),
+        kilde = mockk<Kilde>(),
+        detaljer = "test",
+    )
+
+    private fun mockOppfyltVurdering(vilkår: Vilkår = Vilkår.AAP): Vurdering.Oppfylt = Vurdering.Oppfylt(
+        vilkår = vilkår,
+        fom = LocalDate.now(),
+        tom = LocalDate.now(),
+        kilde = mockk<Kilde>(),
+        detaljer = "test",
+    )
+
+    private fun mockIkkeOppfyltVurdering(vilkår: Vilkår = Vilkår.AAP): Vurdering.IkkeOppfylt = Vurdering.IkkeOppfylt(
+        vilkår = vilkår,
+        fom = LocalDate.now(),
+        tom = LocalDate.now(),
+        kilde = mockk<Kilde>(),
+        detaljer = "test",
+    )
+
+    @Test
+    fun `hentUtfallForVilkår skal gi KREVER_MANUELL_VURDERING hvis noen vurderinger på vilkåret krever manuell vurdering`() {
+        val aapVurderingManuell = mockKreverManuellVurdering()
+        val aapVurderingOppfylt = mockOppfyltVurdering()
+        val vurderinger = listOf(aapVurderingManuell, aapVurderingOppfylt)
+        val utfall = hentUtfallForVilkår(Vilkår.AAP, vurderinger)
+        assert(utfall == Utfall.KREVER_MANUELL_VURDERING)
+    }
+
+    @Test
+    fun `hentUtfallForVilkår skal gi IKKE_OPPFYLT hvis noen vurderinger på vilkåret ikke er oppfylt`() {
+        val aapVurderingOppfylt = mockOppfyltVurdering()
+        val aapVurderingIkkeOppfylt = mockIkkeOppfyltVurdering()
+        val vurderinger = listOf(aapVurderingOppfylt, aapVurderingIkkeOppfylt)
+        val utfall = hentUtfallForVilkår(Vilkår.AAP, vurderinger)
+        assert(utfall == Utfall.IKKE_OPPFYLT)
+    }
+
+    @Test
+    fun `hentUtfallForVilkår skal gi OPPFYLT hvis alle vurderinger på vilkåret oppfylt`() {
+        val aapVurderingOppfylt = mockOppfyltVurdering()
+        val vurderinger = listOf(aapVurderingOppfylt)
+        val utfall = hentUtfallForVilkår(Vilkår.AAP, vurderinger)
+        assert(utfall == Utfall.OPPFYLT)
+    }
+
+    private fun mockSaksopplysning(vilkår: Vilkår = Vilkår.AAP): Saksopplysning = Saksopplysning(
+        vilkår = vilkår,
+        fom = LocalDate.now(),
+        tom = LocalDate.now(),
+        detaljer = "test",
+        kilde = mockk<Kilde>(),
+        typeSaksopplysning = mockk<TypeSaksopplysning>(),
+        saksbehandler = "test",
+    )
+
+    @Test
+    fun `settUtfall svarer med utfall sålenge behandlingen er enten vilkårsvurdert, til beslutter, eller iverksatt`() {
+        val saksopplysning = mockSaksopplysning()
+
+        val iverksatt = mockk<BehandlingIverksatt>()
+        every { iverksatt.vilkårsvurderinger } returns emptyList()
+        val iverksattUtfall = settUtfall(iverksatt, saksopplysning)
+        assert(iverksattUtfall == Utfall.OPPFYLT.name)
+
+        val vilkårsvurdert = mockk<BehandlingVilkårsvurdert>()
+        every { vilkårsvurdert.vilkårsvurderinger } returns emptyList()
+        val vilkårsvurdertUtfall = settUtfall(vilkårsvurdert, saksopplysning)
+        assert(vilkårsvurdertUtfall == Utfall.OPPFYLT.name)
+
+        val tilBeslutter = mockk<BehandlingVilkårsvurdert>()
+        every { tilBeslutter.vilkårsvurderinger } returns emptyList()
+        val tilBeslutterUtfall = settUtfall(vilkårsvurdert, saksopplysning)
+        assert(tilBeslutterUtfall == Utfall.OPPFYLT.name)
+    }
+
+    @Test
+    fun `settSamletUtfall svarer med IKKE_OPPFYLT hvis noen av utfallene ikke er oppfylt`() {
+        val behandling = mockk<BehandlingIverksatt>()
+        val saksopplysninger = listOf(mockSaksopplysning())
+        val ikkeOppfyltVurdering = mockIkkeOppfyltVurdering()
+        val vilkårsvurderinger = listOf(ikkeOppfyltVurdering)
+        every { behandling.vilkårsvurderinger } returns vilkårsvurderinger
+
+        val samletUtfall = settSamletUtfall(behandling, saksopplysninger)
+        assert(samletUtfall == Utfall.IKKE_OPPFYLT.name)
+    }
+
+    @Test
+    fun `settSamletUtfall svarer med KREVER_MANUELL_VURDERING hvis noen av utfallene er Krever Manuell Vurdering`() {
+        val behandling = mockk<BehandlingIverksatt>()
+        val saksopplysninger = listOf(mockSaksopplysning())
+        val manuellVurdering = mockKreverManuellVurdering()
+        val vilkårsvurderinger = listOf(manuellVurdering)
+        every { behandling.vilkårsvurderinger } returns vilkårsvurderinger
+
+        val samletUtfall = settSamletUtfall(behandling, saksopplysninger)
+        assert(samletUtfall == Utfall.KREVER_MANUELL_VURDERING.name)
+    }
+
+    @Test
+    fun `settSamletUtfall svarer kun med OPPFYLT hvis alle vurderingene er oppfylt`() {
+        val behandling = mockk<BehandlingIverksatt>()
+        val saksopplysninger = listOf(mockSaksopplysning())
+        val oppfyltVurdering = mockOppfyltVurdering()
+        val vilkårsvurderinger = listOf(oppfyltVurdering)
+        every { behandling.vilkårsvurderinger } returns vilkårsvurderinger
+
+        val samletUtfallOppfylt = settSamletUtfall(behandling, saksopplysninger)
+        assert(samletUtfallOppfylt == Utfall.OPPFYLT.name)
+
+        val ikkeOppfyltVurdering = mockIkkeOppfyltVurdering()
+        every { behandling.vilkårsvurderinger } returns listOf(oppfyltVurdering, ikkeOppfyltVurdering, oppfyltVurdering)
+        val samletUtfallIkkeOppfylt = settSamletUtfall(behandling, saksopplysninger)
+        assert(samletUtfallIkkeOppfylt == Utfall.IKKE_OPPFYLT.name)
+
+        val manuellVurdering = mockKreverManuellVurdering()
+        every { behandling.vilkårsvurderinger } returns listOf(oppfyltVurdering, manuellVurdering, oppfyltVurdering)
+        val samletUtfallManuellVurdering = settSamletUtfall(behandling, saksopplysninger)
+        assert(samletUtfallManuellVurdering == Utfall.KREVER_MANUELL_VURDERING.name)
+    }
+
+    @Test
+    fun `settBeslutter skal kun svare med beslutter hvis behandlingen er iverksatt, eller til beslutter`() {
+        val beslutter = "Test Beslutter"
+
+        val behandlingIverksatt = mockk<BehandlingIverksatt>()
+        every { behandlingIverksatt.beslutter } returns beslutter
+        val iverksattBeslutter = settBeslutter(behandlingIverksatt)
+        assert(iverksattBeslutter == beslutter)
+
+        val behandlingTilBeslutter = mockk<BehandlingTilBeslutter>()
+        every { behandlingTilBeslutter.beslutter } returns beslutter
+        val tilBeslutter = settBeslutter(behandlingTilBeslutter)
+        assert(tilBeslutter == beslutter)
+
+        val behandlingVilkårsvurdert = mockk<BehandlingVilkårsvurdert>()
+        val vilkårsvurdertBeslutter = settBeslutter(behandlingVilkårsvurdert)
+        assert(vilkårsvurdertBeslutter == null)
+    }
+}


### PR DESCRIPTION
## Beskrivelse
Skrevet enhetstester til det meste av funksjonene som er i `SammenstillingForBehandlingDTO`

## Kommentarer
* Fjernet `private` fra `hentUtfallForVilkår` for å få skrevet test av implementasjonen dens.
* Tar gjerne kommentarer på hvordan vi evt best legger inn en tilstand-property på de ulike behandling-interfacene (se todo-kommentar her: https://github.com/navikt/tiltakspenger-vedtak/compare/test-av-sammenstilling-for-behandling-dto?expand=1#diff-19a1a69406e283e5e043f9383c3d63596f0ccf8da219eadbcfef9d8107cc370fR168)