### PR TITLE
Flyttet tilgangslogikken inn i domenet. 

### DIFF
--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/routes/behandling/BehandlingRoutes.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/routes/behandling/BehandlingRoutes.kt
@@ -145,14 +145,10 @@ fun Route.behandlingRoutes(
         val saksbehandler = innloggetSaksbehandlerProvider.hentInnloggetSaksbehandler(call)
             ?: return@post call.respond(message = "JWTToken ikke funnet", status = HttpStatusCode.Unauthorized)
 
-        val isAdmin = saksbehandler.roller.contains(Rolle.ADMINISTRATOR)
-
-        check(saksbehandler.roller.contains(Rolle.SAKSBEHANDLER) || isAdmin) { "Saksbehandler må være saksbehandler eller administrator" }
-
         val behandlingId = call.parameters["behandlingId"]?.let { BehandlingId.fromDb(it) }
             ?: return@post call.respond(message = "BehandlingId ikke funnet", status = HttpStatusCode.NotFound)
 
-        behandlingService.avbrytBehandling(behandlingId, saksbehandler.navIdent, isAdmin)
+        behandlingService.avbrytBehandling(behandlingId, saksbehandler)
 
         call.respond(message = "{}", status = HttpStatusCode.OK)
     }

--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/service/behandling/BehandlingService.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/service/behandling/BehandlingService.kt
@@ -4,6 +4,7 @@ import no.nav.tiltakspenger.domene.behandling.Søknadsbehandling
 import no.nav.tiltakspenger.domene.behandling.Tiltak
 import no.nav.tiltakspenger.domene.saksopplysning.Saksopplysning
 import no.nav.tiltakspenger.felles.BehandlingId
+import no.nav.tiltakspenger.felles.Saksbehandler
 
 interface BehandlingService {
     fun hentBehandling(behandlingId: BehandlingId): Søknadsbehandling?
@@ -12,9 +13,15 @@ interface BehandlingService {
     fun leggTilSaksopplysning(behandlingId: BehandlingId, saksopplysning: Saksopplysning)
     fun oppdaterTiltak(behandlingId: BehandlingId, tiltak: List<Tiltak>)
     fun sendTilBeslutter(behandlingId: BehandlingId, saksbehandler: String)
-    fun sendTilbakeTilSaksbehandler(behandlingId: BehandlingId, beslutter: String, begrunnelse: String?, isAdmin: Boolean)
+    fun sendTilbakeTilSaksbehandler(
+        behandlingId: BehandlingId,
+        beslutter: String,
+        begrunnelse: String?,
+        isAdmin: Boolean,
+    )
+
     suspend fun iverksett(behandlingId: BehandlingId, saksbehandler: String)
     fun startBehandling(behandlingId: BehandlingId, saksbehandler: String)
-    fun avbrytBehandling(behandlingId: BehandlingId, saksbehandler: String, isAdmin: Boolean)
+    fun avbrytBehandling(behandlingId: BehandlingId, saksbehandler: Saksbehandler)
     fun hentBehandlingForIdent(ident: String): List<Søknadsbehandling>
 }

--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/service/behandling/BehandlingServiceImpl.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/service/behandling/BehandlingServiceImpl.kt
@@ -12,6 +12,7 @@ import no.nav.tiltakspenger.domene.behandling.Tiltak
 import no.nav.tiltakspenger.domene.saksopplysning.Saksopplysning
 import no.nav.tiltakspenger.felles.BehandlingId
 import no.nav.tiltakspenger.felles.Periode
+import no.nav.tiltakspenger.felles.Saksbehandler
 import no.nav.tiltakspenger.vedtak.db.DataSource
 import no.nav.tiltakspenger.vedtak.repository.attestering.AttesteringRepo
 import no.nav.tiltakspenger.vedtak.repository.behandling.BehandlingRepo
@@ -116,7 +117,6 @@ class BehandlingServiceImpl(
             begrunnelse = null,
             beslutter = saksbehandler,
         )
-
         sessionOf(DataSource.hikariDataSource).use {
             it.transaction { txSession ->
                 behandlingRepo.lagre(iverksattBehandling, txSession)
@@ -143,12 +143,11 @@ class BehandlingServiceImpl(
         behandlingRepo.lagre(behandling.startBehandling(saksbehandler))
     }
 
-    override fun avbrytBehandling(behandlingId: BehandlingId, saksbehandler: String, isAdmin: Boolean) {
+    override fun avbrytBehandling(behandlingId: BehandlingId, saksbehandler: Saksbehandler) {
         val behandling = hentBehandling(behandlingId)
             ?: throw NotFoundException("Fant ikke behandlingen med behandlingId: $behandlingId")
 
-        check(behandling.saksbehandler == saksbehandler || isAdmin) { "Kan ikke avbryte en behandling som ikke er din" }
-        behandlingRepo.lagre(behandling.avbrytBehandling())
+        behandlingRepo.lagre(behandling.avbrytBehandling(saksbehandler))
     }
 
     override fun hentBehandlingForIdent(ident: String): List<Søknadsbehandling> {

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/domene/behandling/Behandling.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/domene/behandling/Behandling.kt
@@ -5,6 +5,7 @@ import no.nav.tiltakspenger.domene.saksopplysning.Saksopplysning
 import no.nav.tiltakspenger.felles.BehandlingId
 import no.nav.tiltakspenger.felles.Periode
 import no.nav.tiltakspenger.felles.SakId
+import no.nav.tiltakspenger.felles.Saksbehandler
 
 data class LeggTilSaksopplysningRespons(
     val behandling: Søknadsbehandling,
@@ -47,7 +48,7 @@ interface Behandling {
         throw IllegalStateException("Kan ikke starte en behandling med denne statusen")
     }
 
-    fun avbrytBehandling(): Søknadsbehandling {
+    fun avbrytBehandling(saksbehandler: Saksbehandler): Søknadsbehandling {
         throw IllegalStateException("Kan ikke avbryte en behandling med denne statusen")
     }
 }

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/domene/behandling/BehandlingVilkårsvurdert.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/domene/behandling/BehandlingVilkårsvurdert.kt
@@ -7,6 +7,7 @@ import no.nav.tiltakspenger.domene.vilkår.Vurdering
 import no.nav.tiltakspenger.felles.BehandlingId
 import no.nav.tiltakspenger.felles.Periode
 import no.nav.tiltakspenger.felles.SakId
+import no.nav.tiltakspenger.felles.Saksbehandler
 
 private val LOG = KotlinLogging.logger {}
 private val SECURELOG = KotlinLogging.logger("tjenestekall")
@@ -106,8 +107,10 @@ data class BehandlingVilkårsvurdert(
     override fun startBehandling(saksbehandler: String): Søknadsbehandling =
         this.copy(saksbehandler = saksbehandler)
 
-    override fun avbrytBehandling(): Søknadsbehandling =
-        this.copy(saksbehandler = null)
+    override fun avbrytBehandling(saksbehandler: Saksbehandler): Søknadsbehandling {
+        check(saksbehandler.isSaksbehandler() || saksbehandler.isAdmin()) { "Kan ikke avbryte en behandling som ikke er din" }
+        return this.copy(saksbehandler = null)
+    }
 
     companion object {
         fun fromDb(

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/domene/behandling/Søknadsbehandling.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/domene/behandling/Søknadsbehandling.kt
@@ -9,6 +9,7 @@ import no.nav.tiltakspenger.domene.vilkår.Vurdering
 import no.nav.tiltakspenger.felles.BehandlingId
 import no.nav.tiltakspenger.felles.Periode
 import no.nav.tiltakspenger.felles.SakId
+import no.nav.tiltakspenger.felles.Saksbehandler
 
 sealed interface Søknadsbehandling : Behandling {
     val søknader: List<Søknad>
@@ -153,9 +154,11 @@ sealed interface Søknadsbehandling : Behandling {
                 saksbehandler = saksbehandler,
             )
 
-        override fun avbrytBehandling(): Søknadsbehandling =
-            this.copy(
+        override fun avbrytBehandling(saksbehandler: Saksbehandler): Søknadsbehandling {
+            check(saksbehandler.isSaksbehandler() || saksbehandler.isAdmin()) { "Kan ikke avbryte en behandling som ikke er din" }
+            return this.copy(
                 saksbehandler = null,
             )
+        }
     }
 }

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/felles/Saksbehandler.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/felles/Saksbehandler.kt
@@ -5,4 +5,9 @@ data class Saksbehandler(
     override val brukernavn: String,
     val epost: String,
     override val roller: List<Rolle>,
-) : Bruker
+) : Bruker {
+
+    fun isAdmin() = roller.contains(Rolle.ADMINISTRATOR)
+    fun isSaksbehandler() = roller.contains(Rolle.BESLUTTER)
+    fun isBeslutter() = roller.contains(Rolle.BESLUTTER)
+}


### PR DESCRIPTION
Jeg har lagt merke til at det har vært en del check-kode spredd litt rundt omkring. Noen i BehandlingServiceImpl, men også noe ute i div Routes.
(Kode som `check(saksbehandler.roller.contains(Rolle.SAKSBEHANDLER) || saksbehandler.roller.contains(Rolle.BESLUTTER)) { "Saksbehandler må være saksbehandler eller beslutter" }`)

Jeg tenker at dette strengt tatt er forretningslogikk, og at det er bedre å samle det så nærme kjernen som mulig. Enten at alt er inne i servicen, men aller helst at det er inne i domenet-modellen. Jeg lagde denne PRen for å prøve å vise hva jeg mener med det. Jeg synes det ble bra, men YMMV.. :) 

Jeg har bare gjort det for en operasjon til å begynne med, jeg tenker det er fint å diskutere prinsippet før vi evt gjør det andre steder også.