### PR TITLE
F - Flyttet utfallsperioder til Behandling-interface, skrevet om sett…

### DIFF
--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/routes/behandling/SammenstillingForBehandlingDTO.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/routes/behandling/SammenstillingForBehandlingDTO.kt
@@ -9,6 +9,8 @@ import no.nav.tiltakspenger.domene.behandling.BehandlingStatus
 import no.nav.tiltakspenger.domene.behandling.BehandlingTilBeslutter
 import no.nav.tiltakspenger.domene.behandling.BehandlingVilkårsvurdert
 import no.nav.tiltakspenger.domene.behandling.Førstegangsbehandling
+import no.nav.tiltakspenger.domene.behandling.UtfallForPeriode
+import no.nav.tiltakspenger.domene.behandling.Utfallsperiode
 import no.nav.tiltakspenger.domene.personopplysninger.Personopplysninger
 import no.nav.tiltakspenger.domene.personopplysninger.søkere
 import no.nav.tiltakspenger.domene.saksopplysning.Saksopplysning
@@ -151,7 +153,7 @@ fun mapSammenstillingDTO(
                         utfall = settUtfall(behandling = behandling, saksopplysning = it),
                     )
                 },
-                samletUtfall = settSamletUtfall(
+                samletUtfall = settSamletUtfallForSaksopplysninger(
                     behandling,
                     behandling.saksopplysninger().filter { kategori.vilkår.contains(it.vilkår) },
                 ),
@@ -186,14 +188,13 @@ fun mapSammenstillingDTO(
                 endretTidspunkt = att.tidspunkt,
             )
         },
-        samletUtfall = settSamletUtfall(
-            behandling,
-            behandling.saksopplysninger(),
+        samletUtfall = settSamletUtfallForUtfallsperioder(
+            utfallsperioder = behandling.utfallsperioder,
         ),
     )
 }
 
-fun settSamletUtfall(behandling: Behandling, saksopplysninger: List<Saksopplysning>): String {
+fun settSamletUtfallForSaksopplysninger(behandling: Behandling, saksopplysninger: List<Saksopplysning>): String {
     if (saksopplysninger.any { s ->
             settUtfall(
                 behandling,
@@ -213,6 +214,22 @@ fun settSamletUtfall(behandling: Behandling, saksopplysninger: List<Saksopplysni
         return Utfall.KREVER_MANUELL_VURDERING.name
     }
     return Utfall.OPPFYLT.name
+}
+
+fun settSamletUtfallForUtfallsperioder(utfallsperioder: List<Utfallsperiode>): String {
+    if (utfallsperioder.any { utfallsperiode ->
+            utfallsperiode.utfall == UtfallForPeriode.KREVER_MANUELL_VURDERING
+        }
+    ) {
+        return Utfall.KREVER_MANUELL_VURDERING.name
+    }
+    if (utfallsperioder.any { utfallsperiode ->
+            utfallsperiode.utfall == UtfallForPeriode.GIR_RETT_TILTAKSPENGER
+        }
+    ) {
+        return Utfall.OPPFYLT.name
+    }
+    return Utfall.IKKE_OPPFYLT.name
 }
 
 fun settUtfall(behandling: Behandling, saksopplysning: Saksopplysning): String {

--- a/app/src/test/kotlin/no/nav/tiltakspenger/vedtak/routes/behandling/SammenstillingForBehandlingDTOTest.kt
+++ b/app/src/test/kotlin/no/nav/tiltakspenger/vedtak/routes/behandling/SammenstillingForBehandlingDTOTest.kt
@@ -147,7 +147,7 @@ class SammenstillingForBehandlingDTOTest {
         val vilkårsvurderinger = listOf(ikkeOppfyltVurdering)
         every { behandling.vilkårsvurderinger } returns vilkårsvurderinger
 
-        val samletUtfall = settSamletUtfall(behandling, saksopplysninger)
+        val samletUtfall = settSamletUtfallForSaksopplysninger(behandling, saksopplysninger)
         assert(samletUtfall == Utfall.IKKE_OPPFYLT.name)
     }
 
@@ -159,7 +159,7 @@ class SammenstillingForBehandlingDTOTest {
         val vilkårsvurderinger = listOf(manuellVurdering)
         every { behandling.vilkårsvurderinger } returns vilkårsvurderinger
 
-        val samletUtfall = settSamletUtfall(behandling, saksopplysninger)
+        val samletUtfall = settSamletUtfallForSaksopplysninger(behandling, saksopplysninger)
         assert(samletUtfall == Utfall.KREVER_MANUELL_VURDERING.name)
     }
 
@@ -171,17 +171,17 @@ class SammenstillingForBehandlingDTOTest {
         val vilkårsvurderinger = listOf(oppfyltVurdering)
         every { behandling.vilkårsvurderinger } returns vilkårsvurderinger
 
-        val samletUtfallOppfylt = settSamletUtfall(behandling, saksopplysninger)
+        val samletUtfallOppfylt = settSamletUtfallForSaksopplysninger(behandling, saksopplysninger)
         assert(samletUtfallOppfylt == Utfall.OPPFYLT.name)
 
         val ikkeOppfyltVurdering = mockIkkeOppfyltVurdering()
         every { behandling.vilkårsvurderinger } returns listOf(oppfyltVurdering, ikkeOppfyltVurdering, oppfyltVurdering)
-        val samletUtfallIkkeOppfylt = settSamletUtfall(behandling, saksopplysninger)
+        val samletUtfallIkkeOppfylt = settSamletUtfallForSaksopplysninger(behandling, saksopplysninger)
         assert(samletUtfallIkkeOppfylt == Utfall.IKKE_OPPFYLT.name)
 
         val manuellVurdering = mockKreverManuellVurdering()
         every { behandling.vilkårsvurderinger } returns listOf(oppfyltVurdering, manuellVurdering, oppfyltVurdering)
-        val samletUtfallManuellVurdering = settSamletUtfall(behandling, saksopplysninger)
+        val samletUtfallManuellVurdering = settSamletUtfallForSaksopplysninger(behandling, saksopplysninger)
         assert(samletUtfallManuellVurdering == Utfall.KREVER_MANUELL_VURDERING.name)
     }
 

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/domene/behandling/Behandling.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/domene/behandling/Behandling.kt
@@ -19,6 +19,7 @@ interface Behandling {
     val saksopplysninger: List<Saksopplysning>
     val tiltak: List<Tiltak>
     val saksbehandler: String?
+    val utfallsperioder: List<Utfallsperiode>
 
     fun saksopplysninger(): List<Saksopplysning> {
         return saksopplysninger.groupBy { it.vilkår }.map { entry ->

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/domene/behandling/BehandlingIverksatt.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/domene/behandling/BehandlingIverksatt.kt
@@ -16,8 +16,8 @@ data class BehandlingIverksatt(
     override val saksopplysninger: List<Saksopplysning>,
     override val tiltak: List<Tiltak>,
     override val saksbehandler: String,
+    override val utfallsperioder: List<Utfallsperiode> = emptyList(),
     val vilkårsvurderinger: List<Vurdering>,
-    val utfallsperioder: List<Utfallsperiode>,
     val beslutter: String,
     val status: BehandlingStatus,
 ) : Førstegangsbehandling {

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/domene/behandling/BehandlingOpprettet.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/domene/behandling/BehandlingOpprettet.kt
@@ -17,6 +17,7 @@ data class BehandlingOpprettet(
     override val saksopplysninger: List<Saksopplysning>,
     override val tiltak: List<Tiltak>,
     override val saksbehandler: String?,
+    override val utfallsperioder: List<Utfallsperiode> = emptyList(),
 ) : Førstegangsbehandling {
 
     companion object {

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/domene/behandling/BehandlingTilBeslutter.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/domene/behandling/BehandlingTilBeslutter.kt
@@ -16,8 +16,8 @@ data class BehandlingTilBeslutter(
     override val saksopplysninger: List<Saksopplysning>,
     override val tiltak: List<Tiltak>,
     override val saksbehandler: String,
+    override val utfallsperioder: List<Utfallsperiode> = emptyList(),
     val vilkårsvurderinger: List<Vurdering>,
-    val utfallsperioder: List<Utfallsperiode>,
     val beslutter: String?,
     val status: BehandlingStatus,
 ) : Førstegangsbehandling {

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/domene/behandling/BehandlingVilkårsvurdert.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/domene/behandling/BehandlingVilkårsvurdert.kt
@@ -21,9 +21,9 @@ data class BehandlingVilkårsvurdert(
     override val saksopplysninger: List<Saksopplysning>,
     override val tiltak: List<Tiltak>,
     override val saksbehandler: String?,
+    override val utfallsperioder: List<Utfallsperiode> = emptyList(),
     val status: BehandlingStatus,
     val vilkårsvurderinger: List<Vurdering>,
-    val utfallsperioder: List<Utfallsperiode>,
 ) : Førstegangsbehandling {
 
     fun vurderPåNytt(): BehandlingVilkårsvurdert {


### PR DESCRIPTION
Utfallsperioder ligger nå på Behandling-interfacet, behandlingens settSamletUtfall er omdøpt til settSamletUtfallForUtfallsperioder og bruker utfallsperiodene i stedet for saksopplysningene.