### PR TITLE
Fjernet en del duplisert kode 

### DIFF
--- a/common/src/main/kotlin/no/nav/tiltakspenger/objectmothers/BehandlingMother.kt
+++ b/common/src/main/kotlin/no/nav/tiltakspenger/objectmothers/BehandlingMother.kt
@@ -18,6 +18,7 @@ import no.nav.tiltakspenger.saksbehandling.domene.saksopplysning.Kilde
 import no.nav.tiltakspenger.saksbehandling.domene.saksopplysning.Saksopplysning
 import no.nav.tiltakspenger.saksbehandling.domene.saksopplysning.TypeSaksopplysning
 import no.nav.tiltakspenger.saksbehandling.domene.vilkår.Vilkår
+import no.nav.tiltakspenger.saksbehandling.domene.vilkår.vilkårsvurder
 import java.time.LocalDate
 
 interface BehandlingMother {
@@ -65,7 +66,7 @@ interface BehandlingMother {
             ).behandling
         } as BehandlingVilkårsvurdert
 
-        return behandling.vurderPåNytt()
+        return behandling.spolTilbake().vilkårsvurder()
     }
 
     fun behandlingVilkårsvurdertAvslag(
@@ -82,7 +83,7 @@ interface BehandlingMother {
             ),
         ).behandling as BehandlingVilkårsvurdert
 
-        return behandling.vurderPåNytt()
+        return behandling.spolTilbake().vilkårsvurder()
     }
 
     fun behandlingTilBeslutterInnvilget(): BehandlingTilBeslutter =

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/domene/behandling/BehandlingTilBeslutter.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/domene/behandling/BehandlingTilBeslutter.kt
@@ -6,9 +6,7 @@ import no.nav.tiltakspenger.felles.Rolle
 import no.nav.tiltakspenger.felles.SakId
 import no.nav.tiltakspenger.felles.Saksbehandler
 import no.nav.tiltakspenger.saksbehandling.domene.saksopplysning.Saksopplysning
-import no.nav.tiltakspenger.saksbehandling.domene.saksopplysning.Saksopplysninger.oppdaterSaksopplysninger
 import no.nav.tiltakspenger.saksbehandling.domene.vilkår.Vurdering
-import no.nav.tiltakspenger.saksbehandling.domene.vilkår.vilkårsvurder
 
 data class BehandlingTilBeslutter(
     override val id: BehandlingId,
@@ -68,27 +66,11 @@ data class BehandlingTilBeslutter(
         )
     }
 
-    override fun leggTilSøknad(søknad: Søknad): BehandlingVilkårsvurdert {
-        return BehandlingOpprettet.leggTilSøknad(
-            behandling = this,
-            søknad = søknad,
-        ).vilkårsvurder()
-    }
+    override fun leggTilSøknad(søknad: Søknad): BehandlingVilkårsvurdert =
+        this.spolTilbake().leggTilSøknad(søknad = søknad)
 
-    override fun leggTilSaksopplysning(saksopplysning: Saksopplysning): LeggTilSaksopplysningRespons {
-        val oppdatertSaksopplysningListe = saksopplysninger.oppdaterSaksopplysninger(saksopplysning)
-        return if (oppdatertSaksopplysningListe == this.saksopplysninger) {
-            LeggTilSaksopplysningRespons(
-                behandling = this,
-                erEndret = false,
-            )
-        } else {
-            LeggTilSaksopplysningRespons(
-                behandling = this.copy(saksopplysninger = oppdatertSaksopplysningListe).vurderPåNytt(),
-                erEndret = true,
-            )
-        }
-    }
+    override fun leggTilSaksopplysning(saksopplysning: Saksopplysning): LeggTilSaksopplysningRespons =
+        this.spolTilbake().leggTilSaksopplysning(saksopplysning)
 
     override fun startBehandling(saksbehandler: Saksbehandler): Førstegangsbehandling {
         check(this.beslutter == null) { "Denne behandlingen har allerede en beslutter" }
@@ -98,15 +80,13 @@ data class BehandlingTilBeslutter(
         )
     }
 
-    private fun vurderPåNytt(): BehandlingVilkårsvurdert {
-        return BehandlingOpprettet(
-            id = id,
-            sakId = sakId,
-            søknader = søknader,
-            vurderingsperiode = vurderingsperiode,
-            saksopplysninger = saksopplysninger,
-            tiltak = tiltak,
-            saksbehandler = saksbehandler,
-        ).vilkårsvurder()
-    }
+    private fun spolTilbake(): BehandlingOpprettet = BehandlingOpprettet(
+        id = this.id,
+        sakId = this.sakId,
+        søknader = this.søknader,
+        vurderingsperiode = this.vurderingsperiode,
+        saksopplysninger = this.saksopplysninger,
+        tiltak = this.tiltak,
+        saksbehandler = this.saksbehandler,
+    )
 }


### PR DESCRIPTION
Vi har innføre en spolTilbake-funksjon i BehandlingTilBeslutter og BehandlingVilkårsvurdert, som returnerer BehandlingOpprettet. Funksjoner som leggTilsøknad og leggTilSaksopplysning kaller så den, og deretter leggTilSøknad/leggTilSaksopplysning på BehandlingOpprettet, i stedet for å duplisere koden i egen klasse.