### PR TITLE
F legg inn en klient som kaller microsoftGraphApi og henter ut saksbehandlers navn.

### DIFF
--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/Configuration.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/Configuration.kt
@@ -84,6 +84,7 @@ object Configuration {
                 "DB_DATABASE" to "vedtak",
                 "DB_HOST" to "localhost",
                 "DB_PORT" to "5433",
+                "MICROSOFT_SCOPE" to "localhost",
             ),
         )
 
@@ -109,6 +110,7 @@ object Configuration {
                 "PDFGEN_URL" to "http://tiltakspenger-pdfgen",
                 "POAO_TILGANG_URL" to "https://poao-tilgang.dev.intern.nav.no",
                 "POAO_TILGANG_SCOPE" to "api://dev-gcp.poao.poao-tilgang/.default",
+                "MICROSOFT_SCOPE" to "https://graph.microsoft.com/.default",
             ),
         )
     private val prodProperties =
@@ -133,6 +135,7 @@ object Configuration {
                 "PDFGEN_URL" to "http://tiltakspenger-pdfgen",
                 "POAO_TILGANG_URL" to "https://poao-tilgang.nais.io",
                 "POAO_TILGANG_SCOPE" to "api://prod-gcp.poao.poao-tilgang/.default",
+                "MICROSOFT_SCOPE" to "https://graph.microsoft.com/.default",
             ),
         )
 
@@ -203,6 +206,18 @@ object Configuration {
 
     fun ouathConfigPdlPip(
         scope: String = config()[Key("PDL_PIP_SCOPE", stringType)],
+        clientId: String = config()[Key("AZURE_APP_CLIENT_ID", stringType)],
+        clientSecret: String = config()[Key("AZURE_APP_CLIENT_SECRET", stringType)],
+        wellknownUrl: String = config()[Key("AZURE_APP_WELL_KNOWN_URL", stringType)],
+    ) = AzureTokenProvider.OauthConfig(
+        scope = scope,
+        clientId = clientId,
+        clientSecret = clientSecret,
+        wellknownUrl = wellknownUrl,
+    )
+
+    fun ouathConfigMicrosoftGraphApi(
+        scope: String = config()[Key("MICROSOFT_SCOPE", stringType)],
         clientId: String = config()[Key("AZURE_APP_CLIENT_ID", stringType)],
         clientSecret: String = config()[Key("AZURE_APP_CLIENT_SECRET", stringType)],
         wellknownUrl: String = config()[Key("AZURE_APP_WELL_KNOWN_URL", stringType)],

--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/clients/pdfgen/BrevFørstegangsvedtakInnvilgelseDTO.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/clients/pdfgen/BrevFørstegangsvedtakInnvilgelseDTO.kt
@@ -24,14 +24,18 @@ private class BrevFørstegangsvedtakInnvilgelseDTO(
 )
 
 internal suspend fun Rammevedtak.tobrevDTO(
-    hentNavn: suspend (Fnr) -> Navn,
+    hentBrukersNavn: suspend (Fnr) -> Navn,
+    hentSaksbehandlersNavn: suspend (String) -> String,
 ): String {
-    val navn = hentNavn(fnr)
+    val brukersNavn = hentBrukersNavn(fnr)
+    val saksbehandlersNavn = hentSaksbehandlersNavn(saksbehandlerNavIdent)
+    val besluttersNavn = hentSaksbehandlersNavn(beslutterNavIdent)
+
     return BrevFørstegangsvedtakInnvilgelseDTO(
         personalia = BrevPersonaliaDTO(
             ident = this.fnr.verdi,
-            fornavn = navn.fornavn,
-            etternavn = navn.mellomnavnOgEtternavn,
+            fornavn = brukersNavn.fornavn,
+            etternavn = brukersNavn.mellomnavnOgEtternavn,
             antallBarn = 0,
         ),
         tiltaksnavn = "TODO pre-mvp",
@@ -39,8 +43,8 @@ internal suspend fun Rammevedtak.tobrevDTO(
         rammevedtakTilDato = periode.tilOgMed.format(norskDatoFormatter),
         saksnummer = saksnummer.verdi,
         barnetillegg = false,
-        saksbehandlerNavn = "TODO pre-mvp beslutterNavn",
-        beslutterNavn = "TODO pre-mvp beslutterNavn",
+        saksbehandlerNavn = saksbehandlersNavn,
+        beslutterNavn = besluttersNavn,
         kontor = "TODO pre-mvp: Dette bør ligge på behandlingen. Se NORG-oppgave i trello.",
         // Dette er vår dato, det brukes typisk når bruker klager på vedtaksbrev på dato ...
         datoForUtsending = LocalDate.now().format(norskDatoFormatter),

--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/clients/pdfgen/DokumentMeldekortDTO.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/clients/pdfgen/DokumentMeldekortDTO.kt
@@ -41,9 +41,9 @@ private data class DokumentMeldekortDTO(
 }
 
 suspend fun Meldekort.UtfyltMeldekort.toPdf(
-    hentNavn: suspend (Fnr) -> Navn,
+    hentBrukersNavn: suspend (Fnr) -> Navn,
 ): JsonNode {
-    val navn = hentNavn(fnr)
+    val navn = hentBrukersNavn(fnr)
     return DokumentMeldekortDTO(
         meldekortId = id.toString(),
         sakId = sakId.toString(),

--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/clients/person/MicrosoftGraphApiClient.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/clients/person/MicrosoftGraphApiClient.kt
@@ -1,0 +1,107 @@
+package no.nav.tiltakspenger.vedtak.clients.person
+
+import arrow.core.Either
+import arrow.core.flatten
+import arrow.core.left
+import arrow.core.right
+import kotlinx.coroutines.future.await
+import mu.KotlinLogging
+import no.nav.tiltakspenger.felles.KunneIkkeHenteNavnForNavIdent
+import no.nav.tiltakspenger.felles.NavIdentClient
+import no.nav.tiltakspenger.felles.sikkerlogg
+import no.nav.tiltakspenger.libs.common.AccessToken
+import no.nav.tiltakspenger.vedtak.db.deserialize
+import java.net.URI
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
+
+private data class MicrosoftGraphResponse(
+    val displayName: String,
+)
+
+private data class ListOfMicrosoftGraphResponse(
+    val value: List<MicrosoftGraphResponse>,
+)
+
+class MicrosoftGraphApiClient(
+    private val getToken: suspend () -> AccessToken,
+    private val timeout: Duration = 1.seconds,
+    private val baseUrl: String = "https://graph.microsoft.com/v1.0",
+    connectTimeout: Duration = 1.seconds,
+) : NavIdentClient {
+    private val log = KotlinLogging.logger { }
+
+    private fun uri(navIdent: String) =
+        URI.create("$baseUrl/v1.0/users?\$select=displayName&\$filter=onPremisesSamAccountName eq '$navIdent'\$count=true")
+
+    private val client =
+        java.net.http.HttpClient
+            .newBuilder()
+            .connectTimeout(connectTimeout.toJavaDuration())
+            .followRedirects(java.net.http.HttpClient.Redirect.NEVER)
+            .build()
+
+    private fun KunneIkkeHenteNavnForNavIdent.mapError(navIdent: String): Nothing {
+        when (this) {
+            KunneIkkeHenteNavnForNavIdent.DeserialiseringAvResponsFeilet -> throw RuntimeException("Feil ved deserialisering av response fra microsoftGraphApi for saksbehandler $navIdent")
+            KunneIkkeHenteNavnForNavIdent.FantIkkeBrukerForNavIdent -> throw RuntimeException("Fant ikke bruker for navident: $navIdent")
+            KunneIkkeHenteNavnForNavIdent.FeilVedHentingAvOnBehalfOfToken -> throw RuntimeException("Feil ved henting av token")
+            KunneIkkeHenteNavnForNavIdent.KallTilMicrosoftGraphApiFeilet -> throw RuntimeException("Kall til microsoftGraphApi feilet")
+        }
+    }
+
+    override suspend fun hentNavnForNavIdent(navIdent: String): String {
+        return hentBrukerinformasjonForNavIdent(navIdent).fold(
+            ifLeft = { it.mapError(navIdent) },
+            ifRight = { brukerInfo ->
+                val saksbehandlersNavn = brukerInfo.displayName.trim()
+                if (saksbehandlersNavn.isBlank()) {
+                    throw RuntimeException("Fant ikke saksbehandlerens navn i microsoftGraphApi $navIdent")
+                }
+                // Todo Kew: Er dette formatet "[Etternavn], [Fornavn]"? Isåfall bør man snu det til "[Fornavn] [Etternavn]"
+                saksbehandlersNavn
+            },
+        )
+    }
+
+    private suspend fun hentBrukerinformasjonForNavIdent(navIdent: String): Either<KunneIkkeHenteNavnForNavIdent, MicrosoftGraphResponse> {
+        return Either.catch {
+            val uri = uri(navIdent)
+            val request = createRequest(uri)
+            val httpResponse = client.sendAsync(request, HttpResponse.BodyHandlers.ofString()).await()
+            val jsonResponse = httpResponse.body().let { deserialize<ListOfMicrosoftGraphResponse>(it) }
+            jsonResponse.let { response ->
+                if (response.value.size != 1) {
+                    log.error("Fant ingen eller flere brukere for navIdent $navIdent: ${response.value.size}. Se sikker logg dersom vi fant flere.")
+                    if (response.value.isNotEmpty()) {
+                        sikkerlogg.error("Fant ingen eller flere brukere for navIdent $navIdent: ${response.value}")
+                    }
+                    KunneIkkeHenteNavnForNavIdent.FantIkkeBrukerForNavIdent.left()
+                } else {
+                    response.value.first().right()
+                }
+            }
+        }.mapLeft {
+            log.error(RuntimeException("Genererer stacktrace for enklere debug")) { "Ukjent feil mot Microsoft Graph Api for bruker $navIdent. Se sikker logg for mer context" }
+            sikkerlogg.error(it) { "Ukjent feil mot Microsoft Graph Api for bruker $navIdent: ${it.message}" }
+            throw it
+        }.flatten()
+    }
+
+    private suspend fun createRequest(
+        uri: URI,
+    ): HttpRequest {
+        return HttpRequest
+            .newBuilder()
+            .uri(uri)
+            .timeout(timeout.toJavaDuration())
+            .header("Accept", "application/json")
+            .header("Authorization", "Bearer ${getToken().value}")
+            .header("ConsistencyLevel", "eventual")
+            .GET()
+            .build()
+    }
+}

--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/context/ApplicationContext.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/context/ApplicationContext.kt
@@ -70,6 +70,7 @@ open class ApplicationContext(
             tilgangsstyringService = personContext.tilgangsstyringService,
             dokdistGateway = dokumentContext.dokdistGateway,
             personService = personContext.personService,
+            navIdentClient = personContext.navIdentClient,
         )
     }
 }

--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/context/FørstegangsbehandlingContext.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/context/FørstegangsbehandlingContext.kt
@@ -1,6 +1,7 @@
 package no.nav.tiltakspenger.vedtak.context
 
 import no.nav.tiltakspenger.distribusjon.ports.DokdistGateway
+import no.nav.tiltakspenger.felles.NavIdentClient
 import no.nav.tiltakspenger.libs.persistering.domene.SessionFactory
 import no.nav.tiltakspenger.libs.persistering.infrastruktur.PostgresSessionFactory
 import no.nav.tiltakspenger.libs.personklient.pdl.TilgangsstyringService
@@ -38,6 +39,7 @@ open class FørstegangsbehandlingContext(
     tilgangsstyringService: TilgangsstyringService,
     personService: PersonService,
     dokdistGateway: DokdistGateway,
+    navIdentClient: NavIdentClient,
 ) {
     open val rammevedtakRepo: RammevedtakRepo by lazy { RammevedtakPostgresRepo(sessionFactory as PostgresSessionFactory) }
     open val behandlingRepo: BehandlingRepo by lazy { BehandlingPostgresRepo(sessionFactory as PostgresSessionFactory) }
@@ -75,6 +77,7 @@ open class FørstegangsbehandlingContext(
             rammevedtakRepo = rammevedtakRepo,
             genererVedtaksbrevGateway = genererVedtaksbrevGateway,
             personService = personService,
+            navIdentClient = navIdentClient,
         )
     }
 

--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/context/PersonContext.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/context/PersonContext.kt
@@ -13,6 +13,7 @@ import no.nav.tiltakspenger.saksbehandling.service.person.PersonService
 import no.nav.tiltakspenger.vedtak.Configuration
 import no.nav.tiltakspenger.vedtak.auditlog.AuditService
 import no.nav.tiltakspenger.vedtak.auth.AzureTokenProvider
+import no.nav.tiltakspenger.vedtak.clients.person.MicrosoftGraphApiClient
 import no.nav.tiltakspenger.vedtak.clients.person.PersonHttpklient
 import no.nav.tiltakspenger.vedtak.clients.poaotilgang.PoaoTilgangClient
 import no.nav.tiltakspenger.vedtak.repository.person.PersonPostgresRepo
@@ -23,6 +24,7 @@ open class PersonContext(
 ) {
     val tokenProviderPdl by lazy { AzureTokenProvider(config = Configuration.ouathConfigPdl()) }
     val tokenProviderPdlPip by lazy { AzureTokenProvider(config = Configuration.ouathConfigPdlPip()) }
+    val tokenProviderMicrosoftGraphApi by lazy { AzureTokenProvider(config = Configuration.ouathConfigMicrosoftGraphApi()) }
 
     open val personGateway: PersonGateway by lazy {
         PersonHttpklient(
@@ -37,6 +39,11 @@ open class PersonContext(
             skjermingBaseUrl = Configuration.skjermingClientConfig().baseUrl,
             getSkjermingToken = tokenProviderSkjerming::getToken,
             sikkerlogg = sikkerlogg,
+        )
+    }
+    open val navIdentClient: MicrosoftGraphApiClient by lazy {
+        MicrosoftGraphApiClient(
+            getToken = tokenProviderMicrosoftGraphApi::getToken,
         )
     }
     private val tokenProviderSkjerming: AzureTokenProvider by lazy { AzureTokenProvider(config = Configuration.oauthConfigSkjerming()) }

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/felles/KunneIkkeHenteNavnForNavIdent.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/felles/KunneIkkeHenteNavnForNavIdent.kt
@@ -1,0 +1,11 @@
+package no.nav.tiltakspenger.felles
+
+sealed interface KunneIkkeHenteNavnForNavIdent {
+    data object FeilVedHentingAvOnBehalfOfToken : KunneIkkeHenteNavnForNavIdent
+
+    data object KallTilMicrosoftGraphApiFeilet : KunneIkkeHenteNavnForNavIdent
+
+    data object DeserialiseringAvResponsFeilet : KunneIkkeHenteNavnForNavIdent
+
+    data object FantIkkeBrukerForNavIdent : KunneIkkeHenteNavnForNavIdent
+}

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/felles/NavIdentClient.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/felles/NavIdentClient.kt
@@ -1,0 +1,5 @@
+package no.nav.tiltakspenger.felles
+
+interface NavIdentClient {
+    suspend fun hentNavnForNavIdent(navIdent: String): String
+}

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/felles/exceptions/IkkeLoggDenneException.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/felles/exceptions/IkkeLoggDenneException.kt
@@ -1,0 +1,5 @@
+package no.nav.tiltakspenger.felles.exceptions
+
+class IkkeLoggDenneException(
+    override val message: String,
+) : RuntimeException(message)

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/meldekort/ports/GenererMeldekortPdfGateway.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/meldekort/ports/GenererMeldekortPdfGateway.kt
@@ -8,6 +8,6 @@ import no.nav.tiltakspenger.saksbehandling.domene.personopplysninger.Navn
 interface GenererMeldekortPdfGateway {
     suspend fun genererMeldekortPdf(
         meldekort: Meldekort.UtfyltMeldekort,
-        hentNavn: suspend (Fnr) -> Navn,
+        hentBrukersNavn: suspend (Fnr) -> Navn,
     ): PdfOgJson
 }

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/ports/GenererVedtaksbrevGateway.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/ports/GenererVedtaksbrevGateway.kt
@@ -9,7 +9,8 @@ import no.nav.tiltakspenger.saksbehandling.domene.vedtak.Rammevedtak
 interface GenererVedtaksbrevGateway {
     suspend fun genererVedtaksbrev(
         vedtak: Rammevedtak,
-        hentNavn: suspend (Fnr) -> Navn,
+        hentBrukersNavn: suspend (Fnr) -> Navn,
+        hentSaksbehandlersNavn: suspend (String) -> String,
     ): Either<KunneIkkeGenererePdf, PdfOgJson>
 }
 

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/service/journalføring/JournalførVedtaksbrevService.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/service/journalføring/JournalførVedtaksbrevService.kt
@@ -3,6 +3,7 @@ package no.nav.tiltakspenger.saksbehandling.service.journalføring
 import arrow.core.Either
 import arrow.core.getOrElse
 import mu.KotlinLogging
+import no.nav.tiltakspenger.felles.NavIdentClient
 import no.nav.tiltakspenger.libs.common.CorrelationId
 import no.nav.tiltakspenger.saksbehandling.ports.GenererVedtaksbrevGateway
 import no.nav.tiltakspenger.saksbehandling.ports.JournalførVedtaksbrevGateway
@@ -15,6 +16,7 @@ class JournalførVedtaksbrevService(
     private val rammevedtakRepo: RammevedtakRepo,
     private val genererVedtaksbrevGateway: GenererVedtaksbrevGateway,
     private val personService: PersonService,
+    private val navIdentClient: NavIdentClient,
 ) {
     private val log = KotlinLogging.logger {}
 
@@ -25,7 +27,11 @@ class JournalførVedtaksbrevService(
         rammevedtakRepo.hentRammevedtakSomSkalJournalføres().forEach { vedtak ->
             log.info { "Journalfører vedtaksbrev for vedtak ${vedtak.id}" }
             Either.catch {
-                val pdfOgJson = genererVedtaksbrevGateway.genererVedtaksbrev(vedtak, personService::hentNavn).getOrElse { return@forEach }
+                val pdfOgJson = genererVedtaksbrevGateway.genererVedtaksbrev(
+                    vedtak = vedtak,
+                    hentBrukersNavn = personService::hentNavn,
+                    hentSaksbehandlersNavn = navIdentClient::hentNavnForNavIdent,
+                ).getOrElse { return@forEach }
                 log.info { "Vedtaksbrev generert for vedtak ${vedtak.id}" }
                 val journalpostId = journalførVedtaksbrevGateway.journalførVedtaksbrev(vedtak, pdfOgJson, correlationId)
                 log.info { "Vedtaksbrev journalført for vedtak ${vedtak.id}" }

--- a/test-common/src/main/kotlin/no/nav/tiltakspenger/common/TestApplicationContext.kt
+++ b/test-common/src/main/kotlin/no/nav/tiltakspenger/common/TestApplicationContext.kt
@@ -181,6 +181,7 @@ class TestApplicationContext : ApplicationContext(TestSessionFactory(), "fake-gi
             personService = personContext.personService,
             tilgangsstyringService = tilgangsstyringFakeGateway,
             dokdistGateway = dokdistFakeGateway,
+            navIdentClient = personContext.navIdentClient,
         ) {
             override val rammevedtakRepo = rammevedtakFakeRepo
             override val behandlingRepo = behandlingFakeRepo

--- a/test-common/src/main/kotlin/no/nav/tiltakspenger/fakes/clients/GenererFakeMeldekortPdfGateway.kt
+++ b/test-common/src/main/kotlin/no/nav/tiltakspenger/fakes/clients/GenererFakeMeldekortPdfGateway.kt
@@ -11,7 +11,7 @@ class GenererFakeMeldekortPdfGateway : GenererMeldekortPdfGateway {
     private val response by lazy { PdfOgJson(PdfA("pdf".toByteArray()), "json") }
     override suspend fun genererMeldekortPdf(
         meldekort: Meldekort.UtfyltMeldekort,
-        hentNavn: suspend (Fnr) -> Navn,
+        hentBrukersNavn: suspend (Fnr) -> Navn,
     ): PdfOgJson {
         return response
     }

--- a/test-common/src/main/kotlin/no/nav/tiltakspenger/fakes/clients/GenererFakeVedtaksbrevGateway.kt
+++ b/test-common/src/main/kotlin/no/nav/tiltakspenger/fakes/clients/GenererFakeVedtaksbrevGateway.kt
@@ -14,7 +14,8 @@ class GenererFakeVedtaksbrevGateway : GenererVedtaksbrevGateway {
     private val response by lazy { PdfOgJson(PdfA("pdf".toByteArray()), "json").right() }
     override suspend fun genererVedtaksbrev(
         vedtak: Rammevedtak,
-        hentNavn: suspend (Fnr) -> Navn,
+        hentBrukersNavn: suspend (Fnr) -> Navn,
+        hentSaksbehandlersNavn: suspend (String) -> String,
     ): Either<KunneIkkeGenererePdf, PdfOgJson> {
         return response
     }


### PR DESCRIPTION
## Beskrivelse
La til interfacet `NavIdentClient` som implementeres av `MicrosoftGraphApiClient`.
Denne klienten henter ut saksbehandlers navn via ident fra microsoft graph api.

Den blir initialisert inne i PersonContext (kan eventuelt flyttes til en ny context)

Har lagt inn kallet for både saksbehandler og beslutter når man genererer brev.

## Kommentarer
Har lagt til ny miljøvariabel for dev og prod:
"MICROSOFT_SCOPE" = "https://graph.microsoft.com"
(lokalt er den bare "localhost")

Har også endret på navngivning i metoder som lå inne fra før:
"hentNavn" -> "hentBrukersNavn"
Synes det er greit å spesifisere at det er brukers navn som hentes siden det nå eksisterer en 'hentSaksbehandlersNavn' i samme scope.