### PR TITLE
Lagrer alle tiltaksdeltaker hendelser

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/App.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/App.kt
@@ -104,7 +104,7 @@ internal fun start(
             { applicationContext.meldekortContext.sendTilMeldekortApiService.sendSaker() },
             { applicationContext.meldekortContext.automatiskMeldekortbehandlingService.behandleBrukersMeldekort(clock) },
 
-            { applicationContext.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere() },
+            { applicationContext.endretTiltaksdeltakerJobb.håndterEndretTiltaksdeltakerHendelser() },
         ).let {
             if (Configuration.isNais()) {
                 it.plus(

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/infra/setup/ApplicationContext.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/infra/setup/ApplicationContext.kt
@@ -61,7 +61,7 @@ import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.arena.A
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.arena.TiltaksdeltakerArenaConsumer
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.jobb.EndretTiltaksdeltakerJobb
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.komet.TiltaksdeltakerKometConsumer
-import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.repository.TiltaksdeltakerKafkaRepository
+import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.repository.TiltaksdeltakerHendelsePostgresRepo
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.teamtiltak.TiltaksdeltakerTeamTiltakConsumer
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.setup.TiltaksdeltakelseContext
 import no.nav.tiltakspenger.saksbehandling.utbetaling.infra.setup.UtbetalingContext
@@ -165,15 +165,15 @@ open class ApplicationContext(
         )
     }
 
-    open val tiltaksdeltakerKafkaRepository: TiltaksdeltakerKafkaRepository by lazy {
-        TiltaksdeltakerKafkaRepository(
+    open val tiltaksdeltakerHendelsePostgresRepo: TiltaksdeltakerHendelsePostgresRepo by lazy {
+        TiltaksdeltakerHendelsePostgresRepo(
             sessionFactory = sessionFactory as PostgresSessionFactory,
             clock = clock,
         )
     }
     open val tiltaksdeltakerService: TiltaksdeltakerService by lazy {
         TiltaksdeltakerService(
-            tiltaksdeltakerKafkaRepository = tiltaksdeltakerKafkaRepository,
+            tiltaksdeltakerHendelsePostgresRepo = tiltaksdeltakerHendelsePostgresRepo,
             søknadRepo = søknadContext.søknadRepo,
             arenaDeltakerMapper = ArenaDeltakerMapper(),
             tiltaksdeltakerRepo = tiltakContext.tiltaksdeltakerRepo,
@@ -183,7 +183,7 @@ open class ApplicationContext(
 
     open val endretTiltaksdeltakerJobb by lazy {
         EndretTiltaksdeltakerJobb(
-            tiltaksdeltakerKafkaRepository = tiltaksdeltakerKafkaRepository,
+            tiltaksdeltakerHendelsePostgresRepo = tiltaksdeltakerHendelsePostgresRepo,
             sakRepo = sakContext.sakRepo,
             oppgaveKlient = oppgaveKlient,
             rammebehandlingRepo = behandlingContext.rammebehandlingRepo,

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/TiltaksdeltakerService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/TiltaksdeltakerService.kt
@@ -39,15 +39,15 @@ class TiltaksdeltakerService(
                 tiltaksdeltaker = tiltaksdeltaker,
             )
 
-            val tiltaksdeltakerKafkaDb = arenaDeltakerMapper.mapArenaDeltaker(
+            val tiltaksdeltakerHendelse = arenaDeltakerMapper.mapArenaDeltaker(
                 eksternId = oppdatertEksternId,
                 arenaKafkaMessage = arenaKafkaMessage,
                 sakId = sakId,
                 tiltaksdeltakerId = tiltaksdeltaker.id,
                 clock = clock,
             )
-            if (tiltaksdeltakerKafkaDb != null) {
-                lagreTiltaksdeltakerHendelse(tiltaksdeltakerKafkaDb, melding)
+            if (tiltaksdeltakerHendelse != null) {
+                lagreTiltaksdeltakerHendelse(tiltaksdeltakerHendelse, melding)
                 log.info { "Lagret melding for arenadeltaker med id $oppdatertEksternId" }
             }
         } else {
@@ -62,8 +62,8 @@ class TiltaksdeltakerService(
         if (tiltaksdeltakerId != null && sakId != null) {
             log.info { "Fant sakId $sakId for komet-deltaker med id $deltakerId" }
             val deltakerV1Dto = deserialize<DeltakerV1Dto>(melding)
-            val tiltaksdeltakerKafkaDb = deltakerV1Dto.toTiltaksdeltakerKafkaDb(sakId, tiltaksdeltakerId)
-            lagreTiltaksdeltakerHendelse(tiltaksdeltakerKafkaDb, melding)
+            val tiltaksdeltakerHendelse = deltakerV1Dto.tilTiltaksdeltakerHendelse(sakId, tiltaksdeltakerId)
+            lagreTiltaksdeltakerHendelse(tiltaksdeltakerHendelse, melding)
             log.info { "Lagret melding for kometdeltaker med id $deltakerId" }
         } else {
             log.info { "Fant ingen sak eller intern deltakerid knyttet til eksternId $deltakerId, lagrer ikke" }
@@ -77,8 +77,8 @@ class TiltaksdeltakerService(
         if (tiltaksdeltakerId != null && sakId != null) {
             log.info { "Fant sakId $sakId for team tiltak-deltaker med id $deltakerId" }
             val avtaleDto = deserialize<AvtaleDto>(melding)
-            val tiltaksdeltakerKafkaDb = avtaleDto.toTiltaksdeltakerKafkaDb(sakId, tiltaksdeltakerId)
-            lagreTiltaksdeltakerHendelse(tiltaksdeltakerKafkaDb, melding)
+            val tiltaksdeltakerHendelse = avtaleDto.tilTiltaksdeltakerHendelse(sakId, tiltaksdeltakerId)
+            lagreTiltaksdeltakerHendelse(tiltaksdeltakerHendelse, melding)
             log.info { "Lagret melding for team tiltak-deltaker med id $deltakerId" }
         } else {
             log.info { "Fant ingen sak eller intern deltakerid knyttet til eksternId $deltakerId, lagrer ikke" }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/TiltaksdeltakerService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/TiltaksdeltakerService.kt
@@ -7,9 +7,9 @@ import no.nav.tiltakspenger.saksbehandling.behandling.ports.SøknadRepo
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.TiltaksdeltakerId
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.arena.ArenaDeltakerMapper
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.arena.ArenaKafkaMessage
+import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelse
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.komet.DeltakerV1Dto
-import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.repository.TiltaksdeltakerKafkaDb
-import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.repository.TiltaksdeltakerKafkaRepository
+import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.repository.TiltaksdeltakerHendelsePostgresRepo
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.teamtiltak.AvtaleDto
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.repo.Tiltaksdeltaker
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.repo.TiltaksdeltakerRepo
@@ -17,7 +17,7 @@ import java.time.Clock
 import java.util.UUID
 
 class TiltaksdeltakerService(
-    private val tiltaksdeltakerKafkaRepository: TiltaksdeltakerKafkaRepository,
+    private val tiltaksdeltakerHendelsePostgresRepo: TiltaksdeltakerHendelsePostgresRepo,
     private val søknadRepo: SøknadRepo,
     private val arenaDeltakerMapper: ArenaDeltakerMapper,
     private val tiltaksdeltakerRepo: TiltaksdeltakerRepo,
@@ -47,7 +47,7 @@ class TiltaksdeltakerService(
                 clock = clock,
             )
             if (tiltaksdeltakerKafkaDb != null) {
-                lagreEllerOppdaterTiltaksdeltaker(tiltaksdeltakerKafkaDb, melding)
+                lagreTiltaksdeltakerHendelse(tiltaksdeltakerKafkaDb, melding)
                 log.info { "Lagret melding for arenadeltaker med id $oppdatertEksternId" }
             }
         } else {
@@ -58,11 +58,12 @@ class TiltaksdeltakerService(
     fun behandleMottattKometdeltaker(deltakerId: UUID, melding: String) {
         val tiltaksdeltakerId = tiltaksdeltakerRepo.hentInternId(deltakerId.toString())
         val sakId = tiltaksdeltakerId?.let { finnSakIdForTiltaksdeltaker(it) }
+
         if (tiltaksdeltakerId != null && sakId != null) {
             log.info { "Fant sakId $sakId for komet-deltaker med id $deltakerId" }
             val deltakerV1Dto = deserialize<DeltakerV1Dto>(melding)
             val tiltaksdeltakerKafkaDb = deltakerV1Dto.toTiltaksdeltakerKafkaDb(sakId, tiltaksdeltakerId)
-            lagreEllerOppdaterTiltaksdeltaker(tiltaksdeltakerKafkaDb, melding)
+            lagreTiltaksdeltakerHendelse(tiltaksdeltakerKafkaDb, melding)
             log.info { "Lagret melding for kometdeltaker med id $deltakerId" }
         } else {
             log.info { "Fant ingen sak eller intern deltakerid knyttet til eksternId $deltakerId, lagrer ikke" }
@@ -72,11 +73,12 @@ class TiltaksdeltakerService(
     fun behandleMottattTeamTiltakdeltaker(deltakerId: String, melding: String) {
         val tiltaksdeltakerId = tiltaksdeltakerRepo.hentInternId(deltakerId)
         val sakId = tiltaksdeltakerId?.let { finnSakIdForTiltaksdeltaker(it) }
+
         if (tiltaksdeltakerId != null && sakId != null) {
             log.info { "Fant sakId $sakId for team tiltak-deltaker med id $deltakerId" }
             val avtaleDto = deserialize<AvtaleDto>(melding)
             val tiltaksdeltakerKafkaDb = avtaleDto.toTiltaksdeltakerKafkaDb(sakId, tiltaksdeltakerId)
-            lagreEllerOppdaterTiltaksdeltaker(tiltaksdeltakerKafkaDb, melding)
+            lagreTiltaksdeltakerHendelse(tiltaksdeltakerKafkaDb, melding)
             log.info { "Lagret melding for team tiltak-deltaker med id $deltakerId" }
         } else {
             log.info { "Fant ingen sak eller intern deltakerid knyttet til eksternId $deltakerId, lagrer ikke" }
@@ -102,7 +104,7 @@ class TiltaksdeltakerService(
         return søknadRepo.finnSakIdForTiltaksdeltakelse(tiltaksdeltakerId)
     }
 
-    private fun lagreEllerOppdaterTiltaksdeltaker(tiltaksdeltakerKafkaDb: TiltaksdeltakerKafkaDb, melding: String) {
-        tiltaksdeltakerKafkaRepository.lagre(tiltaksdeltakerKafkaDb, melding)
+    private fun lagreTiltaksdeltakerHendelse(tiltaksdeltakerHendelse: TiltaksdeltakerHendelse, melding: String) {
+        tiltaksdeltakerHendelsePostgresRepo.lagre(tiltaksdeltakerHendelse, melding)
     }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/TiltaksdeltakerService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/TiltaksdeltakerService.kt
@@ -8,6 +8,7 @@ import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.TiltaksdeltakerId
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.arena.ArenaDeltakerMapper
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.arena.ArenaKafkaMessage
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelse
+import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelseKilde
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.komet.DeltakerV1Dto
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.repository.TiltaksdeltakerHendelsePostgresRepo
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.teamtiltak.AvtaleDto
@@ -47,7 +48,7 @@ class TiltaksdeltakerService(
                 clock = clock,
             )
             if (tiltaksdeltakerHendelse != null) {
-                lagreTiltaksdeltakerHendelse(tiltaksdeltakerHendelse, melding)
+                lagreTiltaksdeltakerHendelse(tiltaksdeltakerHendelse, melding, TiltaksdeltakerHendelseKilde.Arena)
                 log.info { "Lagret melding for arenadeltaker med id $oppdatertEksternId" }
             }
         } else {
@@ -63,7 +64,7 @@ class TiltaksdeltakerService(
             log.info { "Fant sakId $sakId for komet-deltaker med id $deltakerId" }
             val deltakerV1Dto = deserialize<DeltakerV1Dto>(melding)
             val tiltaksdeltakerHendelse = deltakerV1Dto.tilTiltaksdeltakerHendelse(sakId, tiltaksdeltakerId)
-            lagreTiltaksdeltakerHendelse(tiltaksdeltakerHendelse, melding)
+            lagreTiltaksdeltakerHendelse(tiltaksdeltakerHendelse, melding, TiltaksdeltakerHendelseKilde.Komet)
             log.info { "Lagret melding for kometdeltaker med id $deltakerId" }
         } else {
             log.info { "Fant ingen sak eller intern deltakerid knyttet til eksternId $deltakerId, lagrer ikke" }
@@ -78,7 +79,7 @@ class TiltaksdeltakerService(
             log.info { "Fant sakId $sakId for team tiltak-deltaker med id $deltakerId" }
             val avtaleDto = deserialize<AvtaleDto>(melding)
             val tiltaksdeltakerHendelse = avtaleDto.tilTiltaksdeltakerHendelse(sakId, tiltaksdeltakerId)
-            lagreTiltaksdeltakerHendelse(tiltaksdeltakerHendelse, melding)
+            lagreTiltaksdeltakerHendelse(tiltaksdeltakerHendelse, melding, TiltaksdeltakerHendelseKilde.TeamTiltak)
             log.info { "Lagret melding for team tiltak-deltaker med id $deltakerId" }
         } else {
             log.info { "Fant ingen sak eller intern deltakerid knyttet til eksternId $deltakerId, lagrer ikke" }
@@ -104,7 +105,7 @@ class TiltaksdeltakerService(
         return søknadRepo.finnSakIdForTiltaksdeltakelse(tiltaksdeltakerId)
     }
 
-    private fun lagreTiltaksdeltakerHendelse(tiltaksdeltakerHendelse: TiltaksdeltakerHendelse, melding: String) {
-        tiltaksdeltakerHendelsePostgresRepo.lagre(tiltaksdeltakerHendelse, melding)
+    private fun lagreTiltaksdeltakerHendelse(tiltaksdeltakerHendelse: TiltaksdeltakerHendelse, melding: String, kilde: TiltaksdeltakerHendelseKilde) {
+        tiltaksdeltakerHendelsePostgresRepo.lagre(tiltaksdeltakerHendelse, melding, kilde)
     }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/arena/ArenaDeltakerMapper.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/arena/ArenaDeltakerMapper.kt
@@ -9,6 +9,7 @@ import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.TiltaksdeltakerId
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.http.toDomain
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelse
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelseId
+import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelseKilde
 import java.time.Clock
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -24,7 +25,9 @@ class ArenaDeltakerMapper {
         tiltaksdeltakerId: TiltaksdeltakerId,
         clock: Clock,
     ): TiltaksdeltakerHendelse? {
-        arenaKafkaMessage.after?.let { return it.toTiltaksdeltakerKafkaDb(eksternId, sakId, tiltaksdeltakerId, clock) }
+        if (arenaKafkaMessage.after != null) {
+            return arenaKafkaMessage.after.tilTiltaksdeltakerHendelse(eksternId, sakId, tiltaksdeltakerId, clock)
+        }
 
         if (arenaKafkaMessage.opType == OperationType.D) {
             log.warn { "Deltakelse med id $eksternId er slettet fra Arena" }
@@ -35,7 +38,7 @@ class ArenaDeltakerMapper {
         }
     }
 
-    private fun ArenaDeltakerKafka.toTiltaksdeltakerKafkaDb(
+    private fun ArenaDeltakerKafka.tilTiltaksdeltakerHendelse(
         eksternId: String,
         sakId: SakId,
         tiltaksdeltakerId: TiltaksdeltakerId,
@@ -55,6 +58,7 @@ class ArenaDeltakerMapper {
             oppgaveSistSjekket = null,
             tiltaksdeltakerId = tiltaksdeltakerId,
             behandlingId = null,
+            kilde = TiltaksdeltakerHendelseKilde.Arena,
         )
     }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/arena/ArenaDeltakerMapper.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/arena/ArenaDeltakerMapper.kt
@@ -9,7 +9,6 @@ import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.TiltaksdeltakerId
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.http.toDomain
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelse
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelseId
-import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelseKilde
 import java.time.Clock
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -58,7 +57,6 @@ class ArenaDeltakerMapper {
             oppgaveSistSjekket = null,
             internDeltakerId = tiltaksdeltakerId,
             behandlingId = null,
-            kilde = TiltaksdeltakerHendelseKilde.Arena,
         )
     }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/arena/ArenaDeltakerMapper.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/arena/ArenaDeltakerMapper.kt
@@ -47,7 +47,7 @@ class ArenaDeltakerMapper {
         val deltakelseFraOgMed = DATO_FRA?.asValidatedLocalDate()
         return TiltaksdeltakerHendelse(
             id = TiltaksdeltakerHendelseId.random(),
-            deltakerId = eksternId,
+            eksternDeltakerId = eksternId,
             deltakelseFraOgMed = deltakelseFraOgMed,
             deltakelseTilOgMed = DATO_TIL?.asValidatedLocalDate(),
             dagerPerUke = ANTALL_DAGER_PR_UKE,
@@ -56,7 +56,7 @@ class ArenaDeltakerMapper {
             sakId = sakId,
             oppgaveId = null,
             oppgaveSistSjekket = null,
-            tiltaksdeltakerId = tiltaksdeltakerId,
+            internDeltakerId = tiltaksdeltakerId,
             behandlingId = null,
             kilde = TiltaksdeltakerHendelseKilde.Arena,
         )

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/arena/ArenaDeltakerMapper.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/arena/ArenaDeltakerMapper.kt
@@ -7,7 +7,8 @@ import no.nav.tiltakspenger.libs.common.SakId
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.TiltakDeltakerstatus
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.TiltaksdeltakerId
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.http.toDomain
-import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.repository.TiltaksdeltakerKafkaDb
+import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelse
+import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelseId
 import java.time.Clock
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -22,7 +23,7 @@ class ArenaDeltakerMapper {
         sakId: SakId,
         tiltaksdeltakerId: TiltaksdeltakerId,
         clock: Clock,
-    ): TiltaksdeltakerKafkaDb? {
+    ): TiltaksdeltakerHendelse? {
         arenaKafkaMessage.after?.let { return it.toTiltaksdeltakerKafkaDb(eksternId, sakId, tiltaksdeltakerId, clock) }
 
         if (arenaKafkaMessage.opType == OperationType.D) {
@@ -39,10 +40,11 @@ class ArenaDeltakerMapper {
         sakId: SakId,
         tiltaksdeltakerId: TiltaksdeltakerId,
         clock: Clock,
-    ): TiltaksdeltakerKafkaDb {
+    ): TiltaksdeltakerHendelse {
         val deltakelseFraOgMed = DATO_FRA?.asValidatedLocalDate()
-        return TiltaksdeltakerKafkaDb(
-            id = eksternId,
+        return TiltaksdeltakerHendelse(
+            id = TiltaksdeltakerHendelseId.random(),
+            deltakerId = eksternId,
             deltakelseFraOgMed = deltakelseFraOgMed,
             deltakelseTilOgMed = DATO_TIL?.asValidatedLocalDate(),
             dagerPerUke = ANTALL_DAGER_PR_UKE,

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/hendelse/TiltaksdeltakerHendelse.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/hendelse/TiltaksdeltakerHendelse.kt
@@ -1,4 +1,4 @@
-package no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.repository
+package no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse
 
 import no.nav.tiltakspenger.libs.common.BehandlingId
 import no.nav.tiltakspenger.libs.common.SakId
@@ -14,10 +14,13 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 
 /**
+ *  [id] Vår interne id for hendelsen
+ *  [deltakerId] Id for deltakelsen fra arena/tiltak/komet
  *  [behandlingId] Er satt dersom endringen førte til at det ble automatisk opprettet en revurdering
  * */
-data class TiltaksdeltakerKafkaDb(
-    val id: String,
+data class TiltaksdeltakerHendelse(
+    val id: TiltaksdeltakerHendelseId,
+    val deltakerId: String,
     val deltakelseFraOgMed: LocalDate?,
     val deltakelseTilOgMed: LocalDate?,
     val dagerPerUke: Float?,

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/hendelse/TiltaksdeltakerHendelse.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/hendelse/TiltaksdeltakerHendelse.kt
@@ -18,7 +18,6 @@ import java.time.LocalDateTime
  *  [internDeltakerId] Vår interne id for deltakelsen
  *  [eksternDeltakerId] Id for deltakelsen fra arena/tiltak/komet
  *  [behandlingId] Er satt dersom endringen førte til at det ble automatisk opprettet en revurdering
- *  [kilde] Kilden til hendelsen, arena/tiltak/komet. Null for hendelser fra før 15.april 2026
  * */
 data class TiltaksdeltakerHendelse(
     val id: TiltaksdeltakerHendelseId,

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/hendelse/TiltaksdeltakerHendelse.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/hendelse/TiltaksdeltakerHendelse.kt
@@ -33,7 +33,6 @@ data class TiltaksdeltakerHendelse(
     val oppgaveId: OppgaveId?,
     val oppgaveSistSjekket: LocalDateTime?,
     val behandlingId: BehandlingId?,
-    val kilde: TiltaksdeltakerHendelseKilde?,
 ) {
 
     fun finnEndringer(

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/hendelse/TiltaksdeltakerHendelse.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/hendelse/TiltaksdeltakerHendelse.kt
@@ -15,12 +15,14 @@ import java.time.LocalDateTime
 
 /**
  *  [id] Vår interne id for hendelsen
- *  [deltakerId] Id for deltakelsen fra arena/tiltak/komet
+ *  [internDeltakerId] Vår interne id for deltakelsen
+ *  [eksternDeltakerId] Id for deltakelsen fra arena/tiltak/komet
  *  [behandlingId] Er satt dersom endringen førte til at det ble automatisk opprettet en revurdering
  * */
 data class TiltaksdeltakerHendelse(
     val id: TiltaksdeltakerHendelseId,
-    val deltakerId: String,
+    val internDeltakerId: TiltaksdeltakerId,
+    val eksternDeltakerId: String,
     val deltakelseFraOgMed: LocalDate?,
     val deltakelseTilOgMed: LocalDate?,
     val dagerPerUke: Float?,
@@ -29,7 +31,6 @@ data class TiltaksdeltakerHendelse(
     val sakId: SakId,
     val oppgaveId: OppgaveId?,
     val oppgaveSistSjekket: LocalDateTime?,
-    val tiltaksdeltakerId: TiltaksdeltakerId,
     val behandlingId: BehandlingId?,
     val kilde: TiltaksdeltakerHendelseKilde,
 ) {

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/hendelse/TiltaksdeltakerHendelse.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/hendelse/TiltaksdeltakerHendelse.kt
@@ -31,6 +31,7 @@ data class TiltaksdeltakerHendelse(
     val oppgaveSistSjekket: LocalDateTime?,
     val tiltaksdeltakerId: TiltaksdeltakerId,
     val behandlingId: BehandlingId?,
+    val kilde: TiltaksdeltakerHendelseKilde,
 ) {
 
     fun finnEndringer(
@@ -54,7 +55,13 @@ data class TiltaksdeltakerHendelse(
             return null
         }
 
-        if (erAvbruttDeltakelse(sammeStatus = sammeStatus, sammeTom = sammeTom, tiltaksdeltakelseFraBehandling, clock = clock)) {
+        if (erAvbruttDeltakelse(
+                sammeStatus = sammeStatus,
+                sammeTom = sammeTom,
+                tiltaksdeltakelseFraBehandling,
+                clock = clock,
+            )
+        ) {
             endringer.add(TiltaksdeltakerEndring.AvbruttDeltakelse)
             return endringer.tilEndringer()
         }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/hendelse/TiltaksdeltakerHendelse.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/hendelse/TiltaksdeltakerHendelse.kt
@@ -18,6 +18,7 @@ import java.time.LocalDateTime
  *  [internDeltakerId] Vår interne id for deltakelsen
  *  [eksternDeltakerId] Id for deltakelsen fra arena/tiltak/komet
  *  [behandlingId] Er satt dersom endringen førte til at det ble automatisk opprettet en revurdering
+ *  [kilde] Kilden til hendelsen, arena/tiltak/komet. Null for hendelser fra før 15.april 2026
  * */
 data class TiltaksdeltakerHendelse(
     val id: TiltaksdeltakerHendelseId,
@@ -32,7 +33,7 @@ data class TiltaksdeltakerHendelse(
     val oppgaveId: OppgaveId?,
     val oppgaveSistSjekket: LocalDateTime?,
     val behandlingId: BehandlingId?,
-    val kilde: TiltaksdeltakerHendelseKilde,
+    val kilde: TiltaksdeltakerHendelseKilde?,
 ) {
 
     fun finnEndringer(

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/hendelse/TiltaksdeltakerHendelseId.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/hendelse/TiltaksdeltakerHendelseId.kt
@@ -1,0 +1,18 @@
+package no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse
+
+import no.nav.tiltakspenger.libs.common.Ulid
+import no.nav.tiltakspenger.libs.common.UlidBase
+import ulid.ULID
+
+data class TiltaksdeltakerHendelseId private constructor(
+    private val ulid: UlidBase,
+) : Ulid by ulid {
+
+    companion object {
+        private const val PREFIX = "tiltaksdeltakerhendelse"
+
+        fun random() = TiltaksdeltakerHendelseId(ulid = UlidBase("${PREFIX}_${ULID.randomULID()}"))
+
+        fun fromString(stringValue: String) = TiltaksdeltakerHendelseId(ulid = UlidBase(stringValue))
+    }
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/hendelse/TiltaksdeltakerHendelseKilde.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/hendelse/TiltaksdeltakerHendelseKilde.kt
@@ -1,0 +1,7 @@
+package no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse
+
+enum class TiltaksdeltakerHendelseKilde {
+    Arena,
+    TeamTiltak,
+    Komet,
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/jobb/EndretTiltaksdeltakerJobb.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/jobb/EndretTiltaksdeltakerJobb.kt
@@ -40,23 +40,25 @@ class EndretTiltaksdeltakerJobb(
             endredeDeltakere.forEach { deltaker ->
                 val sakId = deltaker.sakId
                 val hendelseId = deltaker.id
-                val eksternDeltakerId = deltaker.deltakerId
-                val tiltaksdeltakerId = deltaker.tiltaksdeltakerId
+                val eksternDeltakerId = deltaker.eksternDeltakerId
+                val internDeltakerId = deltaker.internDeltakerId
+
+                val logIder = "sakId $sakId / intern deltakerId $internDeltakerId / ekstern deltakerId $eksternDeltakerId / hendelseId $hendelseId"
 
                 Either.catch {
                     val sak = sakRepo.hentForSakId(sakId)!!
 
-                    sak.oppdaterAutomatiskeSøknadsbehandlingerPåVent(tiltaksdeltakerId)
+                    sak.oppdaterAutomatiskeSøknadsbehandlingerPåVent(internDeltakerId)
 
                     val endringer = sak.finnEndringer(deltaker)
 
                     if (endringer == null) {
-                        log.info { "Fant ingen endringer for sakId $sakId og deltakerId $tiltaksdeltakerId / $eksternDeltakerId" }
+                        log.info { "Fant ingen endringer for $logIder" }
                         tiltaksdeltakerHendelsePostgresRepo.slett(hendelseId)
                         return@forEach
                     }
 
-                    val revurderingSomSkalOpprettes = sak.vurderRevurdering(tiltaksdeltakerId, endringer)
+                    val revurderingSomSkalOpprettes = sak.vurderRevurdering(internDeltakerId, endringer)
 
                     if (revurderingSomSkalOpprettes != null) {
                         val kommando = StartRevurderingKommando(
@@ -76,9 +78,9 @@ class EndretTiltaksdeltakerJobb(
 
                         tiltaksdeltakerHendelsePostgresRepo.lagreBehandlingId(hendelseId, revurdering.id)
 
-                        log.info { "Opprettet revurdering med id ${revurdering.id} / type ${revurdering.resultat::class.simpleName} for endret tiltaksdeltakelse $tiltaksdeltakerId / $eksternDeltakerId" }
+                        log.info { "Opprettet revurdering med id ${revurdering.id} / type ${revurdering.resultat::class.simpleName} for endret tiltaksdeltakelse: $logIder" }
                     } else {
-                        log.info { "Tiltaksdeltakelse $eksternDeltakerId er endret uten å opprette revurdering, oppretter oppgave" }
+                        log.info { "Tiltaksdeltakelse er endret uten å opprette revurdering, oppretter oppgave ($logIder)" }
 
                         val oppgaveId = oppgaveKlient.opprettOppgaveUtenDuplikatkontroll(
                             sak.fnr,
@@ -88,10 +90,10 @@ class EndretTiltaksdeltakerJobb(
 
                         tiltaksdeltakerHendelsePostgresRepo.lagreOppgaveId(hendelseId, oppgaveId)
 
-                        log.info { "Lagret oppgaveId $oppgaveId for tiltaksdeltakelse $eksternDeltakerId" }
+                        log.info { "Lagret oppgaveId $oppgaveId for tiltaksdeltakelse: $logIder" }
                     }
                 }.onLeft {
-                    log.error(it) { "Feil ved opprettelse av oppgave/revurdering for endret tiltaksdeltakelse (deltakelseId $eksternDeltakerId - sakId $sakId)" }
+                    log.error(it) { "Feil ved opprettelse av oppgave/revurdering for endret tiltaksdeltakelse ($logIder)" }
                 }
             }
         }.onLeft {
@@ -115,7 +117,7 @@ class EndretTiltaksdeltakerJobb(
     }
 
     private fun Sak.finnEndringer(deltaker: TiltaksdeltakerHendelse): TiltaksdeltakerEndringer? {
-        val tiltaksdeltakerId = deltaker.tiltaksdeltakerId
+        val tiltaksdeltakerId = deltaker.internDeltakerId
 
         val vedtatteBehandlingerMedRelevantTiltaksdeltakelse = rammevedtaksliste.innvilgetTidslinje.verdier
             .filter { vedtak ->

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/jobb/EndretTiltaksdeltakerJobb.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/jobb/EndretTiltaksdeltakerJobb.kt
@@ -27,77 +27,93 @@ class EndretTiltaksdeltakerJobb(
     private val rammebehandlingRepo: RammebehandlingRepo,
     private val clock: Clock,
     private val startRevurderingService: StartRevurderingService,
-
 ) {
     private val log = KotlinLogging.logger {}
 
-    suspend fun opprettOppgaveEllerRevurderingForEndredeDeltakere() {
+    suspend fun håndterEndretTiltaksdeltakerHendelser() {
         Either.catch {
-            val endredeDeltakere = tiltaksdeltakerHendelsePostgresRepo.hentAlleUtenOppgaveEllerBehandling(
+            val ubehandledeHendelser = tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede(
                 sistOppdatertTidligereEnn = nå(clock).minusMinutes(15),
             )
 
-            endredeDeltakere.forEach { deltaker ->
-                val sakId = deltaker.sakId
-                val hendelseId = deltaker.id
-                val eksternDeltakerId = deltaker.eksternDeltakerId
-                val internDeltakerId = deltaker.internDeltakerId
+            val hendelserPerDeltaker = ubehandledeHendelser.groupBy { it.internDeltakerId }
 
-                val logIder = "sakId $sakId / intern deltakerId $internDeltakerId / ekstern deltakerId $eksternDeltakerId / hendelseId $hendelseId"
+            hendelserPerDeltaker.forEach { (_, hendelser) ->
+                val nyesteHendelse = hendelser.last()
 
-                Either.catch {
-                    val sak = sakRepo.hentForSakId(sakId)!!
-
-                    sak.oppdaterAutomatiskeSøknadsbehandlingerPåVent(internDeltakerId)
-
-                    val endringer = sak.finnEndringer(deltaker)
-
-                    if (endringer == null) {
-                        log.info { "Fant ingen endringer for $logIder" }
-                        tiltaksdeltakerHendelsePostgresRepo.slett(hendelseId)
-                        return@forEach
+                // Marker eldre hendelser for samme deltaker som behandlet uten videre håndtering
+                hendelser.dropLast(1).forEach { eldreHendelse ->
+                    log.info {
+                        "Hendelse ${eldreHendelse.id} er erstattet av en nyere hendelse for deltaker ${eldreHendelse.internDeltakerId}"
                     }
-
-                    val revurderingSomSkalOpprettes = sak.vurderRevurdering(internDeltakerId, endringer)
-
-                    if (revurderingSomSkalOpprettes != null) {
-                        val kommando = StartRevurderingKommando(
-                            sakId = sak.id,
-                            correlationId = CorrelationId.generate(),
-                            saksbehandler = null,
-                            revurderingType = revurderingSomSkalOpprettes.type,
-                            vedtakIdSomOmgjøres = revurderingSomSkalOpprettes.vedtakIdSomOmgjøres,
-                            klagebehandlingId = null,
-                            automatiskOpprettetGrunn = AutomatiskOpprettetRevurderingGrunn(
-                                endringer = endringer,
-                                hendelseId = hendelseId.toString(),
-                            ),
-                        )
-
-                        val (_, revurdering) = startRevurderingService.startRevurdering(kommando, sak)
-
-                        tiltaksdeltakerHendelsePostgresRepo.lagreBehandlingId(hendelseId, revurdering.id)
-
-                        log.info { "Opprettet revurdering med id ${revurdering.id} / type ${revurdering.resultat::class.simpleName} for endret tiltaksdeltakelse: $logIder" }
-                    } else {
-                        log.info { "Tiltaksdeltakelse er endret uten å opprette revurdering, oppretter oppgave ($logIder)" }
-
-                        val oppgaveId = oppgaveKlient.opprettOppgaveUtenDuplikatkontroll(
-                            sak.fnr,
-                            Oppgavebehov.ENDRET_TILTAKDELTAKER,
-                            endringer.getOppgaveTilleggstekst(),
-                        )
-
-                        tiltaksdeltakerHendelsePostgresRepo.lagreOppgaveId(hendelseId, oppgaveId)
-
-                        log.info { "Lagret oppgaveId $oppgaveId for tiltaksdeltakelse: $logIder" }
-                    }
-                }.onLeft {
-                    log.error(it) { "Feil ved opprettelse av oppgave/revurdering for endret tiltaksdeltakelse ($logIder)" }
+                    tiltaksdeltakerHendelsePostgresRepo.markerSomBehandletOgIgnorert(eldreHendelse.id)
                 }
+
+                behandleHendelse(nyesteHendelse)
             }
         }.onLeft {
             log.error(it) { "Feil ved opprettelse av oppgaver/revurderinger for endret tiltaksdeltakelse" }
+        }
+    }
+
+    private suspend fun behandleHendelse(deltakerHendelse: TiltaksdeltakerHendelse) {
+        val sakId = deltakerHendelse.sakId
+        val hendelseId = deltakerHendelse.id
+        val eksternDeltakerId = deltakerHendelse.eksternDeltakerId
+        val internDeltakerId = deltakerHendelse.internDeltakerId
+
+        val logIder =
+            "sakId $sakId / intern deltakerId $internDeltakerId / ekstern deltakerId $eksternDeltakerId / hendelseId $hendelseId"
+
+        Either.catch {
+            val sak = sakRepo.hentForSakId(sakId)!!
+
+            sak.oppdaterAutomatiskeSøknadsbehandlingerPåVent(internDeltakerId)
+
+            val endringer = sak.finnEndringer(deltakerHendelse)
+
+            if (endringer == null) {
+                log.info { "Fant ingen endringer for $logIder" }
+                tiltaksdeltakerHendelsePostgresRepo.markerSomBehandletOgIgnorert(hendelseId)
+                return
+            }
+
+            val revurderingSomSkalOpprettes = sak.vurderRevurdering(internDeltakerId, endringer)
+
+            if (revurderingSomSkalOpprettes != null) {
+                val kommando = StartRevurderingKommando(
+                    sakId = sak.id,
+                    correlationId = CorrelationId.generate(),
+                    saksbehandler = null,
+                    revurderingType = revurderingSomSkalOpprettes.type,
+                    vedtakIdSomOmgjøres = revurderingSomSkalOpprettes.vedtakIdSomOmgjøres,
+                    klagebehandlingId = null,
+                    automatiskOpprettetGrunn = AutomatiskOpprettetRevurderingGrunn(
+                        endringer = endringer,
+                        hendelseId = hendelseId.toString(),
+                    ),
+                )
+
+                val (_, revurdering) = startRevurderingService.startRevurdering(kommando, sak)
+
+                tiltaksdeltakerHendelsePostgresRepo.markerSomBehandletMedRevurdering(hendelseId, revurdering.id)
+
+                log.info { "Opprettet revurdering med id ${revurdering.id} / type ${revurdering.resultat::class.simpleName} for endret tiltaksdeltakelse: $logIder" }
+            } else {
+                log.info { "Tiltaksdeltakelse er endret uten å opprette revurdering, oppretter oppgave ($logIder)" }
+
+                val oppgaveId = oppgaveKlient.opprettOppgaveUtenDuplikatkontroll(
+                    sak.fnr,
+                    Oppgavebehov.ENDRET_TILTAKDELTAKER,
+                    endringer.getOppgaveTilleggstekst(),
+                )
+
+                tiltaksdeltakerHendelsePostgresRepo.markerSomBehandletMedOppgave(hendelseId, oppgaveId)
+
+                log.info { "Lagret oppgaveId $oppgaveId for tiltaksdeltakelse: $logIder" }
+            }
+        }.onLeft {
+            log.error(it) { "Feil ved opprettelse av oppgave/revurdering for endret tiltaksdeltakelse ($logIder)" }
         }
     }
 
@@ -160,7 +176,8 @@ class EndretTiltaksdeltakerJobb(
         }
 
         if (endringer.forlengelse != null) {
-            return vurderRevurderingForForlengelse(endringer.forlengelse!!)
+            val forlengelse = vurderRevurderingForForlengelse(endringer.forlengelse!!)
+            if (forlengelse != null) return forlengelse
         }
 
         return when {

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/jobb/EndretTiltaksdeltakerJobb.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/jobb/EndretTiltaksdeltakerJobb.kt
@@ -33,7 +33,7 @@ class EndretTiltaksdeltakerJobb(
     suspend fun håndterEndretTiltaksdeltakerHendelser() {
         Either.catch {
             val hendelserPerDeltaker = tiltaksdeltakerHendelsePostgresRepo
-                .hentUbehandlede(nå(clock).minusMinutes(MINUTES_DELAY))
+                .hentUbehandlede(MINUTTER_FORSINKELSE)
                 .groupBy { it.internDeltakerId }
 
             hendelserPerDeltaker.forEach { (_, hendelser) ->
@@ -121,7 +121,7 @@ class EndretTiltaksdeltakerJobb(
             .filter { it.søknad.tiltak?.tiltaksdeltakerId == tiltaksdeltakerId && it.erUnderAutomatiskBehandling && it.ventestatus.erSattPåVent }
             .forEach {
                 it.oppdaterVenterTil(
-                    nyVenterTil = nå(clock).plusMinutes(MINUTES_DELAY), // venter i tilfelle det kommer flere endringer
+                    nyVenterTil = nå(clock).plusMinutes(MINUTTER_FORSINKELSE), // venter i tilfelle det kommer flere endringer
                     clock = clock,
                 ).let { behandling ->
                     rammebehandlingRepo.lagre(behandling)
@@ -251,7 +251,9 @@ class EndretTiltaksdeltakerJobb(
     }
 
     companion object {
-        private const val MINUTES_DELAY: Long = 15L
+        // Vi legger til en liten forsinkelse for behandling av hendelser
+        // i tilfelle det kommer flere hendelser for samme deltakelse i løpet av kort tid
+        private const val MINUTTER_FORSINKELSE: Long = 15L
     }
 }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/jobb/EndretTiltaksdeltakerJobb.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/jobb/EndretTiltaksdeltakerJobb.kt
@@ -32,11 +32,9 @@ class EndretTiltaksdeltakerJobb(
 
     suspend fun håndterEndretTiltaksdeltakerHendelser() {
         Either.catch {
-            val ubehandledeHendelser = tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede(
-                sistOppdatertTidligereEnn = nå(clock).minusMinutes(15),
-            )
-
-            val hendelserPerDeltaker = ubehandledeHendelser.groupBy { it.internDeltakerId }
+            val hendelserPerDeltaker = tiltaksdeltakerHendelsePostgresRepo
+                .hentUbehandlede(nå(clock).minusMinutes(MINUTES_DELAY))
+                .groupBy { it.internDeltakerId }
 
             hendelserPerDeltaker.forEach { (_, hendelser) ->
                 val nyesteHendelse = hendelser.last()
@@ -123,7 +121,7 @@ class EndretTiltaksdeltakerJobb(
             .filter { it.søknad.tiltak?.tiltaksdeltakerId == tiltaksdeltakerId && it.erUnderAutomatiskBehandling && it.ventestatus.erSattPåVent }
             .forEach {
                 it.oppdaterVenterTil(
-                    nyVenterTil = nå(clock).plusMinutes(15), // venter i 15 minutter i tilfelle det kommer flere endringer
+                    nyVenterTil = nå(clock).plusMinutes(MINUTES_DELAY), // venter i tilfelle det kommer flere endringer
                     clock = clock,
                 ).let { behandling ->
                     rammebehandlingRepo.lagre(behandling)
@@ -250,6 +248,10 @@ class EndretTiltaksdeltakerJobb(
             type = StartRevurderingType.OMGJØRING,
             vedtakIdSomOmgjøres = vedtakMedRelevantTiltaksdeltakelse.single().id,
         )
+    }
+
+    companion object {
+        private const val MINUTES_DELAY: Long = 15L
     }
 }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/jobb/EndretTiltaksdeltakerJobb.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/jobb/EndretTiltaksdeltakerJobb.kt
@@ -36,6 +36,8 @@ class EndretTiltaksdeltakerJobb(
                 .hentUbehandlede(MINUTTER_FORSINKELSE)
                 .groupBy { it.internDeltakerId }
 
+            log.debug { "Fant $hendelserPerDeltaker hendelser for endret tiltaksdeltakelse som skal behandles" }
+
             hendelserPerDeltaker.forEach { (_, hendelser) ->
                 val nyesteHendelse = hendelser.last()
 

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/jobb/EndretTiltaksdeltakerJobb.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/jobb/EndretTiltaksdeltakerJobb.kt
@@ -15,13 +15,13 @@ import no.nav.tiltakspenger.saksbehandling.behandling.service.behandling.StartRe
 import no.nav.tiltakspenger.saksbehandling.sak.Sak
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.TiltaksdeltakerId
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.domene.AutomatiskOpprettetRevurderingGrunn
-import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.repository.TiltaksdeltakerKafkaDb
-import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.repository.TiltaksdeltakerKafkaRepository
+import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelse
+import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.repository.TiltaksdeltakerHendelsePostgresRepo
 import java.time.Clock
 import java.time.LocalDate
 
 class EndretTiltaksdeltakerJobb(
-    private val tiltaksdeltakerKafkaRepository: TiltaksdeltakerKafkaRepository,
+    private val tiltaksdeltakerHendelsePostgresRepo: TiltaksdeltakerHendelsePostgresRepo,
     private val sakRepo: SakRepo,
     private val oppgaveKlient: OppgaveKlient,
     private val rammebehandlingRepo: RammebehandlingRepo,
@@ -33,13 +33,14 @@ class EndretTiltaksdeltakerJobb(
 
     suspend fun opprettOppgaveEllerRevurderingForEndredeDeltakere() {
         Either.catch {
-            val endredeDeltakere = tiltaksdeltakerKafkaRepository.hentAlleUtenOppgaveEllerBehandling(
+            val endredeDeltakere = tiltaksdeltakerHendelsePostgresRepo.hentAlleUtenOppgaveEllerBehandling(
                 sistOppdatertTidligereEnn = nå(clock).minusMinutes(15),
             )
 
             endredeDeltakere.forEach { deltaker ->
                 val sakId = deltaker.sakId
-                val eksternDeltakerId = deltaker.id
+                val hendelseId = deltaker.id
+                val eksternDeltakerId = deltaker.deltakerId
                 val tiltaksdeltakerId = deltaker.tiltaksdeltakerId
 
                 Either.catch {
@@ -51,7 +52,7 @@ class EndretTiltaksdeltakerJobb(
 
                     if (endringer == null) {
                         log.info { "Fant ingen endringer for sakId $sakId og deltakerId $tiltaksdeltakerId / $eksternDeltakerId" }
-                        tiltaksdeltakerKafkaRepository.slett(eksternDeltakerId)
+                        tiltaksdeltakerHendelsePostgresRepo.slett(hendelseId)
                         return@forEach
                     }
 
@@ -67,13 +68,13 @@ class EndretTiltaksdeltakerJobb(
                             klagebehandlingId = null,
                             automatiskOpprettetGrunn = AutomatiskOpprettetRevurderingGrunn(
                                 endringer = endringer,
-                                hendelseId = eksternDeltakerId,
+                                hendelseId = hendelseId.toString(),
                             ),
                         )
 
                         val (_, revurdering) = startRevurderingService.startRevurdering(kommando, sak)
 
-                        tiltaksdeltakerKafkaRepository.lagreBehandlingId(eksternDeltakerId, revurdering.id)
+                        tiltaksdeltakerHendelsePostgresRepo.lagreBehandlingId(hendelseId, revurdering.id)
 
                         log.info { "Opprettet revurdering med id ${revurdering.id} / type ${revurdering.resultat::class.simpleName} for endret tiltaksdeltakelse $tiltaksdeltakerId / $eksternDeltakerId" }
                     } else {
@@ -85,7 +86,7 @@ class EndretTiltaksdeltakerJobb(
                             endringer.getOppgaveTilleggstekst(),
                         )
 
-                        tiltaksdeltakerKafkaRepository.lagreOppgaveId(eksternDeltakerId, oppgaveId)
+                        tiltaksdeltakerHendelsePostgresRepo.lagreOppgaveId(hendelseId, oppgaveId)
 
                         log.info { "Lagret oppgaveId $oppgaveId for tiltaksdeltakelse $eksternDeltakerId" }
                     }
@@ -113,7 +114,7 @@ class EndretTiltaksdeltakerJobb(
             }
     }
 
-    private fun Sak.finnEndringer(deltaker: TiltaksdeltakerKafkaDb): TiltaksdeltakerEndringer? {
+    private fun Sak.finnEndringer(deltaker: TiltaksdeltakerHendelse): TiltaksdeltakerEndringer? {
         val tiltaksdeltakerId = deltaker.tiltaksdeltakerId
 
         val vedtatteBehandlingerMedRelevantTiltaksdeltakelse = rammevedtaksliste.innvilgetTidslinje.verdier

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/komet/DeltakerV1Dto.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/komet/DeltakerV1Dto.kt
@@ -6,7 +6,8 @@ import no.nav.tiltakspenger.libs.tiltak.toDeltakerStatusDTO
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.TiltakDeltakerstatus
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.TiltaksdeltakerId
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.http.toDomain
-import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.repository.TiltaksdeltakerKafkaDb
+import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelse
+import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelseId
 import java.time.LocalDate
 import java.util.UUID
 
@@ -23,8 +24,9 @@ data class DeltakerV1Dto(
     )
 
     fun toTiltaksdeltakerKafkaDb(sakId: SakId, tiltaksdeltakerId: TiltaksdeltakerId) =
-        TiltaksdeltakerKafkaDb(
-            id = id.toString(),
+        TiltaksdeltakerHendelse(
+            id = TiltaksdeltakerHendelseId.random(),
+            deltakerId = id.toString(),
             deltakelseFraOgMed = startDato,
             deltakelseTilOgMed = sluttDato,
             dagerPerUke = dagerPerUke,

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/komet/DeltakerV1Dto.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/komet/DeltakerV1Dto.kt
@@ -27,7 +27,7 @@ data class DeltakerV1Dto(
     fun tilTiltaksdeltakerHendelse(sakId: SakId, tiltaksdeltakerId: TiltaksdeltakerId) =
         TiltaksdeltakerHendelse(
             id = TiltaksdeltakerHendelseId.random(),
-            deltakerId = id.toString(),
+            eksternDeltakerId = id.toString(),
             deltakelseFraOgMed = startDato,
             deltakelseTilOgMed = sluttDato,
             dagerPerUke = dagerPerUke,
@@ -36,7 +36,7 @@ data class DeltakerV1Dto(
             sakId = sakId,
             oppgaveId = null,
             oppgaveSistSjekket = null,
-            tiltaksdeltakerId = tiltaksdeltakerId,
+            internDeltakerId = tiltaksdeltakerId,
             behandlingId = null,
             kilde = TiltaksdeltakerHendelseKilde.Komet,
         )

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/komet/DeltakerV1Dto.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/komet/DeltakerV1Dto.kt
@@ -8,6 +8,7 @@ import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.TiltaksdeltakerId
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.http.toDomain
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelse
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelseId
+import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelseKilde
 import java.time.LocalDate
 import java.util.UUID
 
@@ -23,7 +24,7 @@ data class DeltakerV1Dto(
         val type: KometDeltakerStatusType,
     )
 
-    fun toTiltaksdeltakerKafkaDb(sakId: SakId, tiltaksdeltakerId: TiltaksdeltakerId) =
+    fun tilTiltaksdeltakerHendelse(sakId: SakId, tiltaksdeltakerId: TiltaksdeltakerId) =
         TiltaksdeltakerHendelse(
             id = TiltaksdeltakerHendelseId.random(),
             deltakerId = id.toString(),
@@ -37,6 +38,7 @@ data class DeltakerV1Dto(
             oppgaveSistSjekket = null,
             tiltaksdeltakerId = tiltaksdeltakerId,
             behandlingId = null,
+            kilde = TiltaksdeltakerHendelseKilde.Komet,
         )
 
     private fun KometDeltakerStatusType.toTiltakDeltakerStatus(): TiltakDeltakerstatus =

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/komet/DeltakerV1Dto.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/komet/DeltakerV1Dto.kt
@@ -8,7 +8,6 @@ import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.TiltaksdeltakerId
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.http.toDomain
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelse
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelseId
-import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelseKilde
 import java.time.LocalDate
 import java.util.UUID
 
@@ -38,7 +37,6 @@ data class DeltakerV1Dto(
             oppgaveSistSjekket = null,
             internDeltakerId = tiltaksdeltakerId,
             behandlingId = null,
-            kilde = TiltaksdeltakerHendelseKilde.Komet,
         )
 
     private fun KometDeltakerStatusType.toTiltakDeltakerStatus(): TiltakDeltakerstatus =

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/repository/TiltaksdeltakerHendelsePostgresRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/repository/TiltaksdeltakerHendelsePostgresRepo.kt
@@ -64,6 +64,7 @@ class TiltaksdeltakerHendelsePostgresRepo(
     fun lagre(
         tiltaksdeltakerHendelse: TiltaksdeltakerHendelse,
         melding: String,
+        kilde: TiltaksdeltakerHendelseKilde,
         sistOppdatert: LocalDateTime = nå(clock),
     ) {
         sessionFactory.withSession { session ->
@@ -118,7 +119,7 @@ class TiltaksdeltakerHendelsePostgresRepo(
                     "oppgave_sist_sjekket" to tiltaksdeltakerHendelse.oppgaveSistSjekket,
                     "tiltaksdeltaker_id" to tiltaksdeltakerHendelse.internDeltakerId.toString(),
                     "behandling_id" to tiltaksdeltakerHendelse.behandlingId?.toString(),
-                    "kilde" to tiltaksdeltakerHendelse.kilde?.tilDb(),
+                    "kilde" to kilde.name,
                 ).asUpdate,
             )
         }
@@ -184,28 +185,6 @@ class TiltaksdeltakerHendelsePostgresRepo(
             oppgaveSistSjekket = localDateTimeOrNull("oppgave_sist_sjekket"),
             internDeltakerId = TiltaksdeltakerId.fromString(string("tiltaksdeltaker_id")),
             behandlingId = stringOrNull("behandling_id")?.let { BehandlingId.fromString(it) },
-            kilde = stringOrNull("kilde")?.tilTiltaksdeltakerHendelseKilde(),
         )
     }
 }
-
-private enum class TiltaksdeltakerHendelseKildeDb {
-    Arena,
-    TeamTiltak,
-    Komet,
-}
-
-private fun TiltaksdeltakerHendelseKilde.tilDb(): String = when (this) {
-    TiltaksdeltakerHendelseKilde.Arena -> TiltaksdeltakerHendelseKildeDb.Arena
-    TiltaksdeltakerHendelseKilde.TeamTiltak -> TiltaksdeltakerHendelseKildeDb.TeamTiltak
-    TiltaksdeltakerHendelseKilde.Komet -> TiltaksdeltakerHendelseKildeDb.Komet
-}.name
-
-private fun String.tilTiltaksdeltakerHendelseKilde(): TiltaksdeltakerHendelseKilde =
-    TiltaksdeltakerHendelseKildeDb.valueOf(this).let {
-        when (it) {
-            TiltaksdeltakerHendelseKildeDb.Arena -> TiltaksdeltakerHendelseKilde.Arena
-            TiltaksdeltakerHendelseKildeDb.TeamTiltak -> TiltaksdeltakerHendelseKilde.TeamTiltak
-            TiltaksdeltakerHendelseKildeDb.Komet -> TiltaksdeltakerHendelseKilde.Komet
-        }
-    }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/repository/TiltaksdeltakerHendelsePostgresRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/repository/TiltaksdeltakerHendelsePostgresRepo.kt
@@ -12,6 +12,7 @@ import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.TiltaksdeltakerId
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelse
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelseId
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelseKilde
+import org.jetbrains.annotations.TestOnly
 import java.time.Clock
 import java.time.LocalDateTime
 
@@ -19,31 +20,6 @@ class TiltaksdeltakerHendelsePostgresRepo(
     private val sessionFactory: PostgresSessionFactory,
     private val clock: Clock,
 ) {
-    fun hent(id: TiltaksdeltakerHendelseId): TiltaksdeltakerHendelse? = sessionFactory.withSession {
-        it.run(
-            sqlQuery(
-                """
-                    select * 
-                    from tiltaksdeltaker_kafka 
-                    where hendelse_id = :hendelse_id
-                """.trimIndent(),
-                "hendelse_id" to id.toString(),
-            ).map { row -> row.tilTiltaksdeltakerHendelse() }.asSingle,
-        )
-    }
-
-    fun hentForDeltakerId(deltakerId: String): List<TiltaksdeltakerHendelse> = sessionFactory.withSession {
-        it.run(
-            sqlQuery(
-                """
-                    select * 
-                    from tiltaksdeltaker_kafka 
-                    where deltaker_id = :deltaker_id
-                """.trimIndent(),
-                "deltaker_id" to deltakerId,
-            ).map { row -> row.tilTiltaksdeltakerHendelse() }.asList,
-        )
-    }
 
     fun hentUbehandlede(minutterForsinkelse: Long = 0): List<TiltaksdeltakerHendelse> =
         sessionFactory.withSession {
@@ -191,6 +167,34 @@ class TiltaksdeltakerHendelsePostgresRepo(
             oppgaveSistSjekket = localDateTimeOrNull("oppgave_sist_sjekket"),
             internDeltakerId = TiltaksdeltakerId.fromString(string("tiltaksdeltaker_id")),
             behandlingId = stringOrNull("behandling_id")?.let { BehandlingId.fromString(it) },
+        )
+    }
+
+    @TestOnly
+    fun hent(id: TiltaksdeltakerHendelseId): TiltaksdeltakerHendelse? = sessionFactory.withSession {
+        it.run(
+            sqlQuery(
+                """
+                    select * 
+                    from tiltaksdeltaker_kafka 
+                    where hendelse_id = :hendelse_id
+                """.trimIndent(),
+                "hendelse_id" to id.toString(),
+            ).map { row -> row.tilTiltaksdeltakerHendelse() }.asSingle,
+        )
+    }
+
+    @TestOnly
+    fun hentForEksternDeltakerId(id: String): List<TiltaksdeltakerHendelse> = sessionFactory.withSession {
+        it.run(
+            sqlQuery(
+                """
+                    select * 
+                    from tiltaksdeltaker_kafka 
+                    where deltaker_id = :deltaker_id
+                """.trimIndent(),
+                "deltaker_id" to id,
+            ).map { row -> row.tilTiltaksdeltakerHendelse() }.asList,
         )
     }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/repository/TiltaksdeltakerHendelsePostgresRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/repository/TiltaksdeltakerHendelsePostgresRepo.kt
@@ -45,16 +45,16 @@ class TiltaksdeltakerHendelsePostgresRepo(
         )
     }
 
-    fun hentAlleUtenOppgaveEllerBehandling(sistOppdatertTidligereEnn: LocalDateTime): List<TiltaksdeltakerHendelse> =
+    fun hentUbehandlede(sistOppdatertTidligereEnn: LocalDateTime): List<TiltaksdeltakerHendelse> =
         sessionFactory.withSession {
             it.run(
                 sqlQuery(
                     """
                         select * 
                         from tiltaksdeltaker_kafka
-                        where oppgave_id is null 
-                          and behandling_id is null 
+                        where behandlet_tidspunkt is null 
                           and sist_oppdatert < :sist_oppdatert
+                        order by sist_oppdatert asc
                     """.trimIndent(),
                     "sist_oppdatert" to sistOppdatertTidligereEnn,
                 ).map { row -> row.tilTiltaksdeltakerHendelse() }.asList,
@@ -125,29 +125,33 @@ class TiltaksdeltakerHendelsePostgresRepo(
         }
     }
 
-    fun slett(id: TiltaksdeltakerHendelseId) {
+    fun markerSomBehandletOgIgnorert(id: TiltaksdeltakerHendelseId) {
         sessionFactory.withSession {
             it.run(
                 sqlQuery(
                     """
-                        delete from tiltaksdeltaker_kafka 
+                        update tiltaksdeltaker_kafka 
+                        set behandlet_tidspunkt = :behandlet_tidspunkt
                         where hendelse_id = :hendelse_id
                     """.trimIndent(),
+                    "behandlet_tidspunkt" to nå(clock),
                     "hendelse_id" to id.toString(),
                 ).asUpdate,
             )
         }
     }
 
-    fun lagreOppgaveId(id: TiltaksdeltakerHendelseId, oppgaveId: OppgaveId) {
+    fun markerSomBehandletMedOppgave(id: TiltaksdeltakerHendelseId, oppgaveId: OppgaveId) {
         sessionFactory.withSession {
             it.run(
                 sqlQuery(
                     """
                         update tiltaksdeltaker_kafka 
-                        set oppgave_id = :oppgave_id 
+                        set behandlet_tidspunkt = :behandlet_tidspunkt,
+                            oppgave_id = :oppgave_id
                         where hendelse_id = :hendelse_id
                     """.trimIndent(),
+                    "behandlet_tidspunkt" to nå(clock),
                     "oppgave_id" to oppgaveId.toString(),
                     "hendelse_id" to id.toString(),
                 ).asUpdate,
@@ -155,15 +159,17 @@ class TiltaksdeltakerHendelsePostgresRepo(
         }
     }
 
-    fun lagreBehandlingId(id: TiltaksdeltakerHendelseId, behandlingId: BehandlingId) {
+    fun markerSomBehandletMedRevurdering(id: TiltaksdeltakerHendelseId, behandlingId: BehandlingId) {
         sessionFactory.withSession {
             it.run(
                 sqlQuery(
                     """
                         update tiltaksdeltaker_kafka 
-                        set behandling_id = :behandling_id 
+                        set behandlet_tidspunkt = :behandlet_tidspunkt,
+                            behandling_id = :behandling_id
                         where hendelse_id = :hendelse_id
                     """.trimIndent(),
+                    "behandlet_tidspunkt" to nå(clock),
                     "behandling_id" to behandlingId.toString(),
                     "hendelse_id" to id.toString(),
                 ).asUpdate,

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/repository/TiltaksdeltakerHendelsePostgresRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/repository/TiltaksdeltakerHendelsePostgresRepo.kt
@@ -118,7 +118,7 @@ class TiltaksdeltakerHendelsePostgresRepo(
                     "oppgave_sist_sjekket" to tiltaksdeltakerHendelse.oppgaveSistSjekket,
                     "tiltaksdeltaker_id" to tiltaksdeltakerHendelse.internDeltakerId.toString(),
                     "behandling_id" to tiltaksdeltakerHendelse.behandlingId?.toString(),
-                    "kilde" to tiltaksdeltakerHendelse.kilde.name,
+                    "kilde" to tiltaksdeltakerHendelse.kilde.toDb().name,
                 ).asUpdate,
             )
         }
@@ -184,6 +184,24 @@ class TiltaksdeltakerHendelsePostgresRepo(
             oppgaveSistSjekket = localDateTimeOrNull("oppgave_sist_sjekket"),
             internDeltakerId = TiltaksdeltakerId.fromString(string("tiltaksdeltaker_id")),
             behandlingId = stringOrNull("behandling_id")?.let { BehandlingId.fromString(it) },
-            kilde = stringOrNull("kilde")?.let { TiltaksdeltakerHendelseKilde.valueOf(it) } ?: TiltaksdeltakerHendelseKilde.Komet,
+            kilde = stringOrNull("kilde")?.let { TiltaksdeltakerHendelseKildeDb.valueOf(it).toDomain() } ?: TiltaksdeltakerHendelseKilde.Komet,
         )
+}
+
+private enum class TiltaksdeltakerHendelseKildeDb {
+    Arena,
+    TeamTiltak,
+    Komet,
+}
+
+private fun TiltaksdeltakerHendelseKilde.toDb(): TiltaksdeltakerHendelseKildeDb = when (this) {
+    TiltaksdeltakerHendelseKilde.Arena -> TiltaksdeltakerHendelseKildeDb.Arena
+    TiltaksdeltakerHendelseKilde.TeamTiltak -> TiltaksdeltakerHendelseKildeDb.TeamTiltak
+    TiltaksdeltakerHendelseKilde.Komet -> TiltaksdeltakerHendelseKildeDb.Komet
+}
+
+private fun TiltaksdeltakerHendelseKildeDb.toDomain(): TiltaksdeltakerHendelseKilde = when (this) {
+    TiltaksdeltakerHendelseKildeDb.Arena -> TiltaksdeltakerHendelseKilde.Arena
+    TiltaksdeltakerHendelseKildeDb.TeamTiltak -> TiltaksdeltakerHendelseKilde.TeamTiltak
+    TiltaksdeltakerHendelseKildeDb.Komet -> TiltaksdeltakerHendelseKilde.Komet
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/repository/TiltaksdeltakerHendelsePostgresRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/repository/TiltaksdeltakerHendelsePostgresRepo.kt
@@ -9,27 +9,42 @@ import no.nav.tiltakspenger.libs.persistering.infrastruktur.sqlQuery
 import no.nav.tiltakspenger.saksbehandling.oppgave.OppgaveId
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.TiltakDeltakerstatus
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.TiltaksdeltakerId
+import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelse
+import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelseId
 import java.time.Clock
 import java.time.LocalDateTime
 
-class TiltaksdeltakerKafkaRepository(
+class TiltaksdeltakerHendelsePostgresRepo(
     private val sessionFactory: PostgresSessionFactory,
     private val clock: Clock,
 ) {
-    fun hent(id: String): TiltaksdeltakerKafkaDb? = sessionFactory.withSession {
+    fun hent(id: TiltaksdeltakerHendelseId): TiltaksdeltakerHendelse? = sessionFactory.withSession {
         it.run(
             sqlQuery(
                 """
                     select * 
                     from tiltaksdeltaker_kafka 
-                    where id = :id
+                    where hendelse_id = :hendelse_id
                 """.trimIndent(),
-                "id" to id,
+                "hendelse_id" to id.toString(),
             ).map { row -> row.toTiltaksdeltakerKafkaDb() }.asSingle,
         )
     }
 
-    fun hentAlleUtenOppgaveEllerBehandling(sistOppdatertTidligereEnn: LocalDateTime): List<TiltaksdeltakerKafkaDb> =
+    fun hentForDeltakerId(deltakerId: String): List<TiltaksdeltakerHendelse> = sessionFactory.withSession {
+        it.run(
+            sqlQuery(
+                """
+                    select * 
+                    from tiltaksdeltaker_kafka 
+                    where deltaker_id = :deltaker_id
+                """.trimIndent(),
+                "deltaker_id" to deltakerId,
+            ).map { row -> row.toTiltaksdeltakerKafkaDb() }.asList,
+        )
+    }
+
+    fun hentAlleUtenOppgaveEllerBehandling(sistOppdatertTidligereEnn: LocalDateTime): List<TiltaksdeltakerHendelse> =
         sessionFactory.withSession {
             it.run(
                 sqlQuery(
@@ -46,7 +61,7 @@ class TiltaksdeltakerKafkaRepository(
         }
 
     fun lagre(
-        tiltaksdeltakerKafkaDb: TiltaksdeltakerKafkaDb,
+        tiltaksdeltakerHendelse: TiltaksdeltakerHendelse,
         melding: String,
         sistOppdatert: LocalDateTime = nå(clock),
     ) {
@@ -55,7 +70,8 @@ class TiltaksdeltakerKafkaRepository(
                 sqlQuery(
                     """
                         insert into tiltaksdeltaker_kafka (
-                            id,
+                            hendelse_id,
+                            deltaker_id,
                             deltakelse_fra_og_med,
                             deltakelse_til_og_med,
                             dager_per_uke,
@@ -69,7 +85,8 @@ class TiltaksdeltakerKafkaRepository(
                             tiltaksdeltaker_id,
                             behandling_id
                         ) values (
-                            :id,
+                            :hendelse_id,
+                            :deltaker_id,
                             :deltakelse_fra_og_med,
                             :deltakelse_til_og_med,
                             :dager_per_uke,
@@ -82,82 +99,77 @@ class TiltaksdeltakerKafkaRepository(
                             :oppgave_sist_sjekket,
                             :tiltaksdeltaker_id,
                             :behandling_id
-                        ) on conflict (id) do update set
-                            deltakelse_fra_og_med = :deltakelse_fra_og_med,
-                            deltakelse_til_og_med = :deltakelse_til_og_med,
-                            dager_per_uke = :dager_per_uke,
-                            deltakelsesprosent = :deltakelsesprosent,
-                            deltakerstatus = :deltakerstatus,
-                            sist_oppdatert = :sist_oppdatert,
-                            melding = :melding
+                        )
                     """.trimIndent(),
-                    "id" to tiltaksdeltakerKafkaDb.id,
-                    "deltakelse_fra_og_med" to tiltaksdeltakerKafkaDb.deltakelseFraOgMed,
-                    "deltakelse_til_og_med" to tiltaksdeltakerKafkaDb.deltakelseTilOgMed,
-                    "dager_per_uke" to tiltaksdeltakerKafkaDb.dagerPerUke,
-                    "deltakelsesprosent" to tiltaksdeltakerKafkaDb.deltakelsesprosent,
-                    "deltakerstatus" to tiltaksdeltakerKafkaDb.deltakerstatus.name,
-                    "sak_id" to tiltaksdeltakerKafkaDb.sakId.toString(),
-                    "oppgave_id" to tiltaksdeltakerKafkaDb.oppgaveId?.toString(),
+                    "hendelse_id" to tiltaksdeltakerHendelse.id.toString(),
+                    "deltaker_id" to tiltaksdeltakerHendelse.deltakerId,
+                    "deltakelse_fra_og_med" to tiltaksdeltakerHendelse.deltakelseFraOgMed,
+                    "deltakelse_til_og_med" to tiltaksdeltakerHendelse.deltakelseTilOgMed,
+                    "dager_per_uke" to tiltaksdeltakerHendelse.dagerPerUke,
+                    "deltakelsesprosent" to tiltaksdeltakerHendelse.deltakelsesprosent,
+                    "deltakerstatus" to tiltaksdeltakerHendelse.deltakerstatus.name,
+                    "sak_id" to tiltaksdeltakerHendelse.sakId.toString(),
+                    "oppgave_id" to tiltaksdeltakerHendelse.oppgaveId?.toString(),
                     "sist_oppdatert" to sistOppdatert,
                     "melding" to melding,
-                    "oppgave_sist_sjekket" to tiltaksdeltakerKafkaDb.oppgaveSistSjekket,
-                    "tiltaksdeltaker_id" to tiltaksdeltakerKafkaDb.tiltaksdeltakerId.toString(),
-                    "behandling_id" to tiltaksdeltakerKafkaDb.behandlingId?.toString(),
+                    "oppgave_sist_sjekket" to tiltaksdeltakerHendelse.oppgaveSistSjekket,
+                    "tiltaksdeltaker_id" to tiltaksdeltakerHendelse.tiltaksdeltakerId.toString(),
+                    "behandling_id" to tiltaksdeltakerHendelse.behandlingId?.toString(),
                 ).asUpdate,
             )
         }
     }
 
-    fun slett(id: String) {
+    fun slett(id: TiltaksdeltakerHendelseId) {
         sessionFactory.withSession {
             it.run(
                 sqlQuery(
                     """
                         delete from tiltaksdeltaker_kafka 
-                        where id = :id
+                        where hendelse_id = :hendelse_id
                     """.trimIndent(),
-                    "id" to id,
+                    "hendelse_id" to id.toString(),
                 ).asUpdate,
             )
         }
     }
 
-    fun lagreOppgaveId(id: String, oppgaveId: OppgaveId) {
+    fun lagreOppgaveId(id: TiltaksdeltakerHendelseId, oppgaveId: OppgaveId) {
         sessionFactory.withSession {
             it.run(
                 sqlQuery(
                     """
                         update tiltaksdeltaker_kafka 
                         set oppgave_id = :oppgave_id 
-                        where id = :id
+                        where hendelse_id = :hendelse_id
                     """.trimIndent(),
                     "oppgave_id" to oppgaveId.toString(),
-                    "id" to id,
+                    "hendelse_id" to id.toString(),
                 ).asUpdate,
             )
         }
     }
 
-    fun lagreBehandlingId(id: String, behandlingId: BehandlingId) {
+    fun lagreBehandlingId(id: TiltaksdeltakerHendelseId, behandlingId: BehandlingId) {
         sessionFactory.withSession {
             it.run(
                 sqlQuery(
                     """
                         update tiltaksdeltaker_kafka 
                         set behandling_id = :behandling_id 
-                        where id = :id
+                        where hendelse_id = :hendelse_id
                     """.trimIndent(),
                     "behandling_id" to behandlingId.toString(),
-                    "id" to id,
+                    "hendelse_id" to id.toString(),
                 ).asUpdate,
             )
         }
     }
 
     private fun Row.toTiltaksdeltakerKafkaDb() =
-        TiltaksdeltakerKafkaDb(
-            id = string("id"),
+        TiltaksdeltakerHendelse(
+            id = TiltaksdeltakerHendelseId.fromString(string("hendelse_id")),
+            deltakerId = string("deltaker_id"),
             deltakelseFraOgMed = localDateOrNull("deltakelse_fra_og_med"),
             deltakelseTilOgMed = localDateOrNull("deltakelse_til_og_med"),
             dagerPerUke = floatOrNull("dager_per_uke"),

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/repository/TiltaksdeltakerHendelsePostgresRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/repository/TiltaksdeltakerHendelsePostgresRepo.kt
@@ -45,7 +45,7 @@ class TiltaksdeltakerHendelsePostgresRepo(
         )
     }
 
-    fun hentUbehandlede(sistOppdatertTidligereEnn: LocalDateTime): List<TiltaksdeltakerHendelse> =
+    fun hentUbehandlede(minutterForsinkelse: Long = 0): List<TiltaksdeltakerHendelse> =
         sessionFactory.withSession {
             it.run(
                 sqlQuery(
@@ -56,7 +56,7 @@ class TiltaksdeltakerHendelsePostgresRepo(
                           and sist_oppdatert < :sist_oppdatert
                         order by sist_oppdatert asc
                     """.trimIndent(),
-                    "sist_oppdatert" to sistOppdatertTidligereEnn,
+                    "sist_oppdatert" to nå(clock).minusMinutes(minutterForsinkelse),
                 ).map { row -> row.tilTiltaksdeltakerHendelse() }.asList,
             )
         }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/repository/TiltaksdeltakerHendelsePostgresRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/repository/TiltaksdeltakerHendelsePostgresRepo.kt
@@ -11,6 +11,7 @@ import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.TiltakDeltakerstatu
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.TiltaksdeltakerId
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelse
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelseId
+import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelseKilde
 import java.time.Clock
 import java.time.LocalDateTime
 
@@ -27,7 +28,7 @@ class TiltaksdeltakerHendelsePostgresRepo(
                     where hendelse_id = :hendelse_id
                 """.trimIndent(),
                 "hendelse_id" to id.toString(),
-            ).map { row -> row.toTiltaksdeltakerKafkaDb() }.asSingle,
+            ).map { row -> row.tilTiltaksdeltakerHendelse() }.asSingle,
         )
     }
 
@@ -40,7 +41,7 @@ class TiltaksdeltakerHendelsePostgresRepo(
                     where deltaker_id = :deltaker_id
                 """.trimIndent(),
                 "deltaker_id" to deltakerId,
-            ).map { row -> row.toTiltaksdeltakerKafkaDb() }.asList,
+            ).map { row -> row.tilTiltaksdeltakerHendelse() }.asList,
         )
     }
 
@@ -56,7 +57,7 @@ class TiltaksdeltakerHendelsePostgresRepo(
                           and sist_oppdatert < :sist_oppdatert
                     """.trimIndent(),
                     "sist_oppdatert" to sistOppdatertTidligereEnn,
-                ).map { row -> row.toTiltaksdeltakerKafkaDb() }.asList,
+                ).map { row -> row.tilTiltaksdeltakerHendelse() }.asList,
             )
         }
 
@@ -83,7 +84,8 @@ class TiltaksdeltakerHendelsePostgresRepo(
                             melding,
                             oppgave_sist_sjekket,
                             tiltaksdeltaker_id,
-                            behandling_id
+                            behandling_id,
+                            kilde
                         ) values (
                             :hendelse_id,
                             :deltaker_id,
@@ -98,7 +100,8 @@ class TiltaksdeltakerHendelsePostgresRepo(
                             :melding,
                             :oppgave_sist_sjekket,
                             :tiltaksdeltaker_id,
-                            :behandling_id
+                            :behandling_id,
+                            :kilde
                         )
                     """.trimIndent(),
                     "hendelse_id" to tiltaksdeltakerHendelse.id.toString(),
@@ -115,6 +118,7 @@ class TiltaksdeltakerHendelsePostgresRepo(
                     "oppgave_sist_sjekket" to tiltaksdeltakerHendelse.oppgaveSistSjekket,
                     "tiltaksdeltaker_id" to tiltaksdeltakerHendelse.tiltaksdeltakerId.toString(),
                     "behandling_id" to tiltaksdeltakerHendelse.behandlingId?.toString(),
+                    "kilde" to tiltaksdeltakerHendelse.kilde.name,
                 ).asUpdate,
             )
         }
@@ -166,7 +170,7 @@ class TiltaksdeltakerHendelsePostgresRepo(
         }
     }
 
-    private fun Row.toTiltaksdeltakerKafkaDb() =
+    private fun Row.tilTiltaksdeltakerHendelse() =
         TiltaksdeltakerHendelse(
             id = TiltaksdeltakerHendelseId.fromString(string("hendelse_id")),
             deltakerId = string("deltaker_id"),
@@ -180,5 +184,6 @@ class TiltaksdeltakerHendelsePostgresRepo(
             oppgaveSistSjekket = localDateTimeOrNull("oppgave_sist_sjekket"),
             tiltaksdeltakerId = TiltaksdeltakerId.fromString(string("tiltaksdeltaker_id")),
             behandlingId = stringOrNull("behandling_id")?.let { BehandlingId.fromString(it) },
+            kilde = stringOrNull("kilde")?.let { TiltaksdeltakerHendelseKilde.valueOf(it) } ?: TiltaksdeltakerHendelseKilde.Komet,
         )
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/repository/TiltaksdeltakerHendelsePostgresRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/repository/TiltaksdeltakerHendelsePostgresRepo.kt
@@ -118,7 +118,7 @@ class TiltaksdeltakerHendelsePostgresRepo(
                     "oppgave_sist_sjekket" to tiltaksdeltakerHendelse.oppgaveSistSjekket,
                     "tiltaksdeltaker_id" to tiltaksdeltakerHendelse.internDeltakerId.toString(),
                     "behandling_id" to tiltaksdeltakerHendelse.behandlingId?.toString(),
-                    "kilde" to tiltaksdeltakerHendelse.kilde.toDb().name,
+                    "kilde" to tiltaksdeltakerHendelse.kilde?.tilDb(),
                 ).asUpdate,
             )
         }
@@ -170,8 +170,8 @@ class TiltaksdeltakerHendelsePostgresRepo(
         }
     }
 
-    private fun Row.tilTiltaksdeltakerHendelse() =
-        TiltaksdeltakerHendelse(
+    private fun Row.tilTiltaksdeltakerHendelse(): TiltaksdeltakerHendelse {
+        return TiltaksdeltakerHendelse(
             id = TiltaksdeltakerHendelseId.fromString(string("hendelse_id")),
             eksternDeltakerId = string("deltaker_id"),
             deltakelseFraOgMed = localDateOrNull("deltakelse_fra_og_med"),
@@ -184,8 +184,9 @@ class TiltaksdeltakerHendelsePostgresRepo(
             oppgaveSistSjekket = localDateTimeOrNull("oppgave_sist_sjekket"),
             internDeltakerId = TiltaksdeltakerId.fromString(string("tiltaksdeltaker_id")),
             behandlingId = stringOrNull("behandling_id")?.let { BehandlingId.fromString(it) },
-            kilde = stringOrNull("kilde")?.let { TiltaksdeltakerHendelseKildeDb.valueOf(it).toDomain() } ?: TiltaksdeltakerHendelseKilde.Komet,
+            kilde = stringOrNull("kilde")?.tilTiltaksdeltakerHendelseKilde(),
         )
+    }
 }
 
 private enum class TiltaksdeltakerHendelseKildeDb {
@@ -194,14 +195,17 @@ private enum class TiltaksdeltakerHendelseKildeDb {
     Komet,
 }
 
-private fun TiltaksdeltakerHendelseKilde.toDb(): TiltaksdeltakerHendelseKildeDb = when (this) {
+private fun TiltaksdeltakerHendelseKilde.tilDb(): String = when (this) {
     TiltaksdeltakerHendelseKilde.Arena -> TiltaksdeltakerHendelseKildeDb.Arena
     TiltaksdeltakerHendelseKilde.TeamTiltak -> TiltaksdeltakerHendelseKildeDb.TeamTiltak
     TiltaksdeltakerHendelseKilde.Komet -> TiltaksdeltakerHendelseKildeDb.Komet
-}
+}.name
 
-private fun TiltaksdeltakerHendelseKildeDb.toDomain(): TiltaksdeltakerHendelseKilde = when (this) {
-    TiltaksdeltakerHendelseKildeDb.Arena -> TiltaksdeltakerHendelseKilde.Arena
-    TiltaksdeltakerHendelseKildeDb.TeamTiltak -> TiltaksdeltakerHendelseKilde.TeamTiltak
-    TiltaksdeltakerHendelseKildeDb.Komet -> TiltaksdeltakerHendelseKilde.Komet
-}
+private fun String.tilTiltaksdeltakerHendelseKilde(): TiltaksdeltakerHendelseKilde =
+    TiltaksdeltakerHendelseKildeDb.valueOf(this).let {
+        when (it) {
+            TiltaksdeltakerHendelseKildeDb.Arena -> TiltaksdeltakerHendelseKilde.Arena
+            TiltaksdeltakerHendelseKildeDb.TeamTiltak -> TiltaksdeltakerHendelseKilde.TeamTiltak
+            TiltaksdeltakerHendelseKildeDb.Komet -> TiltaksdeltakerHendelseKilde.Komet
+        }
+    }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/repository/TiltaksdeltakerHendelsePostgresRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/repository/TiltaksdeltakerHendelsePostgresRepo.kt
@@ -105,7 +105,7 @@ class TiltaksdeltakerHendelsePostgresRepo(
                         )
                     """.trimIndent(),
                     "hendelse_id" to tiltaksdeltakerHendelse.id.toString(),
-                    "deltaker_id" to tiltaksdeltakerHendelse.deltakerId,
+                    "deltaker_id" to tiltaksdeltakerHendelse.eksternDeltakerId,
                     "deltakelse_fra_og_med" to tiltaksdeltakerHendelse.deltakelseFraOgMed,
                     "deltakelse_til_og_med" to tiltaksdeltakerHendelse.deltakelseTilOgMed,
                     "dager_per_uke" to tiltaksdeltakerHendelse.dagerPerUke,
@@ -116,7 +116,7 @@ class TiltaksdeltakerHendelsePostgresRepo(
                     "sist_oppdatert" to sistOppdatert,
                     "melding" to melding,
                     "oppgave_sist_sjekket" to tiltaksdeltakerHendelse.oppgaveSistSjekket,
-                    "tiltaksdeltaker_id" to tiltaksdeltakerHendelse.tiltaksdeltakerId.toString(),
+                    "tiltaksdeltaker_id" to tiltaksdeltakerHendelse.internDeltakerId.toString(),
                     "behandling_id" to tiltaksdeltakerHendelse.behandlingId?.toString(),
                     "kilde" to tiltaksdeltakerHendelse.kilde.name,
                 ).asUpdate,
@@ -173,7 +173,7 @@ class TiltaksdeltakerHendelsePostgresRepo(
     private fun Row.tilTiltaksdeltakerHendelse() =
         TiltaksdeltakerHendelse(
             id = TiltaksdeltakerHendelseId.fromString(string("hendelse_id")),
-            deltakerId = string("deltaker_id"),
+            eksternDeltakerId = string("deltaker_id"),
             deltakelseFraOgMed = localDateOrNull("deltakelse_fra_og_med"),
             deltakelseTilOgMed = localDateOrNull("deltakelse_til_og_med"),
             dagerPerUke = floatOrNull("dager_per_uke"),
@@ -182,7 +182,7 @@ class TiltaksdeltakerHendelsePostgresRepo(
             sakId = SakId.fromString(string("sak_id")),
             oppgaveId = stringOrNull("oppgave_id")?.let { OppgaveId(it) },
             oppgaveSistSjekket = localDateTimeOrNull("oppgave_sist_sjekket"),
-            tiltaksdeltakerId = TiltaksdeltakerId.fromString(string("tiltaksdeltaker_id")),
+            internDeltakerId = TiltaksdeltakerId.fromString(string("tiltaksdeltaker_id")),
             behandlingId = stringOrNull("behandling_id")?.let { BehandlingId.fromString(it) },
             kilde = stringOrNull("kilde")?.let { TiltaksdeltakerHendelseKilde.valueOf(it) } ?: TiltaksdeltakerHendelseKilde.Komet,
         )

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/teamtiltak/AvtaleDto.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/teamtiltak/AvtaleDto.kt
@@ -93,7 +93,7 @@ data class AvtaleDto(
     fun tilTiltaksdeltakerHendelse(sakId: SakId, tiltaksdeltakerId: TiltaksdeltakerId) =
         TiltaksdeltakerHendelse(
             id = TiltaksdeltakerHendelseId.random(),
-            deltakerId = avtaleId.toString(),
+            eksternDeltakerId = avtaleId.toString(),
             deltakelseFraOgMed = startDato,
             deltakelseTilOgMed = sluttDato,
             dagerPerUke = antallDagerPerUke?.toFloat(),
@@ -102,7 +102,7 @@ data class AvtaleDto(
             sakId = sakId,
             oppgaveId = null,
             oppgaveSistSjekket = null,
-            tiltaksdeltakerId = tiltaksdeltakerId,
+            internDeltakerId = tiltaksdeltakerId,
             behandlingId = null,
             kilde = TiltaksdeltakerHendelseKilde.TeamTiltak,
         )

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/teamtiltak/AvtaleDto.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/teamtiltak/AvtaleDto.kt
@@ -7,7 +7,6 @@ import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.TiltaksdeltakerId
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.http.toDomain
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelse
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelseId
-import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelseKilde
 import java.time.LocalDate
 import java.util.UUID
 
@@ -104,7 +103,6 @@ data class AvtaleDto(
             oppgaveSistSjekket = null,
             internDeltakerId = tiltaksdeltakerId,
             behandlingId = null,
-            kilde = TiltaksdeltakerHendelseKilde.TeamTiltak,
         )
 }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/teamtiltak/AvtaleDto.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/teamtiltak/AvtaleDto.kt
@@ -5,7 +5,8 @@ import no.nav.tiltakspenger.libs.tiltak.TiltakResponsDTO.DeltakerStatusDTO
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.TiltakDeltakerstatus
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.TiltaksdeltakerId
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.http.toDomain
-import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.repository.TiltaksdeltakerKafkaDb
+import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelse
+import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelseId
 import java.time.LocalDate
 import java.util.UUID
 
@@ -89,8 +90,9 @@ data class AvtaleDto(
     }
 
     fun toTiltaksdeltakerKafkaDb(sakId: SakId, tiltaksdeltakerId: TiltaksdeltakerId) =
-        TiltaksdeltakerKafkaDb(
-            id = avtaleId.toString(),
+        TiltaksdeltakerHendelse(
+            id = TiltaksdeltakerHendelseId.random(),
+            deltakerId = avtaleId.toString(),
             deltakelseFraOgMed = startDato,
             deltakelseTilOgMed = sluttDato,
             dagerPerUke = antallDagerPerUke?.toFloat(),

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/teamtiltak/AvtaleDto.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/teamtiltak/AvtaleDto.kt
@@ -7,6 +7,7 @@ import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.TiltaksdeltakerId
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.http.toDomain
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelse
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelseId
+import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelseKilde
 import java.time.LocalDate
 import java.util.UUID
 
@@ -89,7 +90,7 @@ data class AvtaleDto(
         OPPDATERTE_AVTALEKRAV,
     }
 
-    fun toTiltaksdeltakerKafkaDb(sakId: SakId, tiltaksdeltakerId: TiltaksdeltakerId) =
+    fun tilTiltaksdeltakerHendelse(sakId: SakId, tiltaksdeltakerId: TiltaksdeltakerId) =
         TiltaksdeltakerHendelse(
             id = TiltaksdeltakerHendelseId.random(),
             deltakerId = avtaleId.toString(),
@@ -103,6 +104,7 @@ data class AvtaleDto(
             oppgaveSistSjekket = null,
             tiltaksdeltakerId = tiltaksdeltakerId,
             behandlingId = null,
+            kilde = TiltaksdeltakerHendelseKilde.TeamTiltak,
         )
 }
 

--- a/src/main/resources/db/migration/V214__tiltaksdeltaker_kafka_hendelse_id.sql
+++ b/src/main/resources/db/migration/V214__tiltaksdeltaker_kafka_hendelse_id.sql
@@ -1,18 +1,57 @@
-ALTER TABLE tiltaksdeltaker_kafka REPLICA IDENTITY FULL;
 
-ALTER TABLE tiltaksdeltaker_kafka DROP CONSTRAINT tiltaksdeltaker_kafka_pkey;
+ALTER TABLE tiltaksdeltaker_kafka
+    REPLICA IDENTITY FULL;
 
-ALTER TABLE tiltaksdeltaker_kafka RENAME COLUMN id TO deltaker_id;
+ALTER TABLE tiltaksdeltaker_kafka
+    DROP CONSTRAINT IF EXISTS tiltaksdeltaker_kafka_pkey;
 
-ALTER TABLE tiltaksdeltaker_kafka ADD COLUMN hendelse_id varchar;
+ALTER TABLE tiltaksdeltaker_kafka
+    RENAME COLUMN id TO deltaker_id;
 
-UPDATE tiltaksdeltaker_kafka SET hendelse_id = 'tiltaksdeltakerhendelse_' || replace(gen_random_uuid()::text, '-', '') WHERE hendelse_id IS NULL;
+ALTER TABLE tiltaksdeltaker_kafka
+    ADD COLUMN IF NOT EXISTS hendelse_id varchar;
 
-ALTER TABLE tiltaksdeltaker_kafka ALTER COLUMN hendelse_id SET NOT NULL;
+-- Generate valid ULID-formatted hendelse_id for existing rows
+-- A ULID is 26 chars of Crockford Base32. We use a temporary function to encode random bytes.
+CREATE OR REPLACE FUNCTION pg_temp.bytes_to_crockford(data bytea) RETURNS text AS
+$$
+DECLARE
+    alphabet text := '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+    result   text := '';
+    bits     int  := 0;
+    buffer   int  := 0;
+    i        int;
+    byte     int;
+BEGIN
+    FOR i IN 0..length(data) - 1
+        LOOP
+            byte := get_byte(data, i);
+            buffer := (buffer << 8) | byte;
+            bits := bits + 8;
+            WHILE bits >= 5
+                LOOP
+                    bits := bits - 5;
+                    result := result || substr(alphabet, ((buffer >> bits) & 31) + 1, 1);
+                END LOOP;
+        END LOOP;
+    IF bits > 0 THEN
+        result := result || substr(alphabet, ((buffer << (5 - bits)) & 31) + 1, 1);
+    END IF;
+    RETURN result;
+END;
+$$ LANGUAGE plpgsql;
 
-ALTER TABLE tiltaksdeltaker_kafka ADD PRIMARY KEY (hendelse_id);
+UPDATE tiltaksdeltaker_kafka
+SET hendelse_id = 'tiltaksdeltakerhendelse_' || pg_temp.bytes_to_crockford(uuid_send(gen_random_uuid()))
+WHERE hendelse_id IS NULL;
 
-ALTER TABLE tiltaksdeltaker_kafka REPLICA IDENTITY DEFAULT;
+ALTER TABLE tiltaksdeltaker_kafka
+    ALTER COLUMN hendelse_id SET NOT NULL;
 
-CREATE INDEX idx_tiltaksdeltaker_kafka_deltaker_id ON tiltaksdeltaker_kafka (deltaker_id);
+ALTER TABLE tiltaksdeltaker_kafka
+    ADD PRIMARY KEY (hendelse_id);
 
+ALTER TABLE tiltaksdeltaker_kafka
+    REPLICA IDENTITY DEFAULT;
+
+CREATE INDEX IF NOT EXISTS idx_tiltaksdeltaker_kafka_deltaker_id ON tiltaksdeltaker_kafka (deltaker_id);

--- a/src/main/resources/db/migration/V214__tiltaksdeltaker_kafka_hendelse_id.sql
+++ b/src/main/resources/db/migration/V214__tiltaksdeltaker_kafka_hendelse_id.sql
@@ -1,3 +1,5 @@
+ALTER TABLE tiltaksdeltaker_kafka REPLICA IDENTITY FULL;
+
 ALTER TABLE tiltaksdeltaker_kafka DROP CONSTRAINT tiltaksdeltaker_kafka_pkey;
 
 ALTER TABLE tiltaksdeltaker_kafka RENAME COLUMN id TO deltaker_id;
@@ -9,6 +11,8 @@ UPDATE tiltaksdeltaker_kafka SET hendelse_id = 'tiltaksdeltakerhendelse_' || rep
 ALTER TABLE tiltaksdeltaker_kafka ALTER COLUMN hendelse_id SET NOT NULL;
 
 ALTER TABLE tiltaksdeltaker_kafka ADD PRIMARY KEY (hendelse_id);
+
+ALTER TABLE tiltaksdeltaker_kafka REPLICA IDENTITY DEFAULT;
 
 CREATE INDEX idx_tiltaksdeltaker_kafka_deltaker_id ON tiltaksdeltaker_kafka (deltaker_id);
 

--- a/src/main/resources/db/migration/V214__tiltaksdeltaker_kafka_hendelse_id.sql
+++ b/src/main/resources/db/migration/V214__tiltaksdeltaker_kafka_hendelse_id.sql
@@ -1,0 +1,14 @@
+ALTER TABLE tiltaksdeltaker_kafka DROP CONSTRAINT tiltaksdeltaker_kafka_pkey;
+
+ALTER TABLE tiltaksdeltaker_kafka RENAME COLUMN id TO deltaker_id;
+
+ALTER TABLE tiltaksdeltaker_kafka ADD COLUMN hendelse_id varchar;
+
+UPDATE tiltaksdeltaker_kafka SET hendelse_id = 'tiltaksdeltakerhendelse_' || replace(gen_random_uuid()::text, '-', '') WHERE hendelse_id IS NULL;
+
+ALTER TABLE tiltaksdeltaker_kafka ALTER COLUMN hendelse_id SET NOT NULL;
+
+ALTER TABLE tiltaksdeltaker_kafka ADD PRIMARY KEY (hendelse_id);
+
+CREATE INDEX idx_tiltaksdeltaker_kafka_deltaker_id ON tiltaksdeltaker_kafka (deltaker_id);
+

--- a/src/main/resources/db/migration/V215__tiltaksdeltaker_kafka_kilde.sql
+++ b/src/main/resources/db/migration/V215__tiltaksdeltaker_kafka_kilde.sql
@@ -1,2 +1,10 @@
-ALTER TABLE tiltaksdeltaker_kafka ADD COLUMN kilde varchar;
+ALTER TABLE tiltaksdeltaker_kafka
+    ADD COLUMN IF NOT EXISTS kilde varchar;
+ALTER TABLE tiltaksdeltaker_kafka
+    ADD COLUMN IF NOT EXISTS behandlet_tidspunkt TIMESTAMPTZ;
+
+UPDATE tiltaksdeltaker_kafka
+SET behandlet_tidspunkt = sist_oppdatert
+WHERE behandlet_tidspunkt IS NULL
+  AND (oppgave_id IS NOT NULL OR behandling_id IS NOT NULL);
 

--- a/src/main/resources/db/migration/V215__tiltaksdeltaker_kafka_kilde.sql
+++ b/src/main/resources/db/migration/V215__tiltaksdeltaker_kafka_kilde.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tiltaksdeltaker_kafka ADD COLUMN kilde varchar;
+

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/infra/repo/TestDataHelper.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/infra/repo/TestDataHelper.kt
@@ -24,7 +24,7 @@ import no.nav.tiltakspenger.saksbehandling.statistikk.saksstatistikk.Saksstatist
 import no.nav.tiltakspenger.saksbehandling.statistikk.stønadsstatistikk.StatistikkStønadPostgresRepo
 import no.nav.tiltakspenger.saksbehandling.søknad.infra.repo.SøknadPostgresRepo
 import no.nav.tiltakspenger.saksbehandling.tilbakekreving.infra.repo.TilbakekrevingBehandlingPostgresRepo
-import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.repository.TiltaksdeltakerKafkaRepository
+import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.repository.TiltaksdeltakerHendelsePostgresRepo
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.repo.TiltaksdeltakerPostgresRepo
 import no.nav.tiltakspenger.saksbehandling.utbetaling.infra.repo.MeldekortvedtakPostgresRepo
 import no.nav.tiltakspenger.saksbehandling.utbetaling.infra.repo.UtbetalingPostgresRepo
@@ -61,7 +61,7 @@ internal class TestDataHelper(
     val meldekortBrukerRepo = BrukersMeldekortPostgresRepo(sessionFactory)
     val meldekortvedtakRepo: MeldekortvedtakRepo = MeldekortvedtakPostgresRepo(sessionFactory)
     val personRepo = PersonPostgresRepo(sessionFactory)
-    val tiltaksdeltakerKafkaRepository = TiltaksdeltakerKafkaRepository(sessionFactory, clock)
+    val tiltaksdeltakerHendelsePostgresRepo = TiltaksdeltakerHendelsePostgresRepo(sessionFactory, clock)
     val personhendelseRepository = PersonhendelseRepository(sessionFactory, clock)
     val identhendelseRepository = IdenthendelseRepository(sessionFactory, clock)
     val benkOversiktRepo = BenkOversiktPostgresRepo(sessionFactory)

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/TiltaksdeltakerServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/TiltaksdeltakerServiceTest.kt
@@ -38,7 +38,7 @@ class TiltaksdeltakerServiceTest {
 
             tiltaksdeltakerService.behandleMottattArenadeltaker(deltakerId, getArenaMeldingString())
 
-            tiltaksdeltakerKafkaRepository.hentForDeltakerId(deltakerId).shouldBeEmpty()
+            tiltaksdeltakerKafkaRepository.hentForEksternDeltakerId(deltakerId).shouldBeEmpty()
         }
     }
 
@@ -68,7 +68,7 @@ class TiltaksdeltakerServiceTest {
 
             tiltaksdeltakerService.behandleMottattArenadeltaker(deltakerId, getArenaMeldingString())
 
-            val hendelser = tiltaksdeltakerKafkaRepository.hentForDeltakerId(id)
+            val hendelser = tiltaksdeltakerKafkaRepository.hentForEksternDeltakerId(id)
             hendelser shouldHaveSize 1
             val tiltaksdeltakerHendelse = hendelser.first()
             tiltaksdeltakerHendelse.deltakelseFraOgMed shouldBe LocalDate.of(2024, 10, 14)
@@ -117,8 +117,8 @@ class TiltaksdeltakerServiceTest {
             oppdatertTiltaksdeltaker?.tiltakstype shouldBe soknadstiltak.typeKode
             oppdatertTiltaksdeltaker?.utdatertEksternId shouldBe id
 
-            tiltaksdeltakerKafkaRepository.hentForDeltakerId(id).shouldBeEmpty()
-            val hendelser = tiltaksdeltakerKafkaRepository.hentForDeltakerId(nyEksternId.toString())
+            tiltaksdeltakerKafkaRepository.hentForEksternDeltakerId(id).shouldBeEmpty()
+            val hendelser = tiltaksdeltakerKafkaRepository.hentForEksternDeltakerId(nyEksternId.toString())
             hendelser shouldHaveSize 1
             val tiltaksdeltakerHendelse = hendelser.first()
             tiltaksdeltakerHendelse.deltakelseFraOgMed shouldBe LocalDate.of(2024, 10, 14)
@@ -163,8 +163,8 @@ class TiltaksdeltakerServiceTest {
             tiltaksdeltakerRepo.hentTiltaksdeltaker(nyEksternId.toString()) shouldNotBe null
             tiltaksdeltakerRepo.hentTiltaksdeltaker(id) shouldBe null
 
-            tiltaksdeltakerKafkaRepository.hentForDeltakerId(nyEksternId.toString()).shouldBeEmpty()
-            tiltaksdeltakerKafkaRepository.hentForDeltakerId(id).shouldBeEmpty()
+            tiltaksdeltakerKafkaRepository.hentForEksternDeltakerId(nyEksternId.toString()).shouldBeEmpty()
+            tiltaksdeltakerKafkaRepository.hentForEksternDeltakerId(id).shouldBeEmpty()
         }
     }
 
@@ -210,7 +210,7 @@ class TiltaksdeltakerServiceTest {
 
             tiltaksdeltakerService.behandleMottattArenadeltaker(deltakerId, getArenaMeldingString())
 
-            val hendelser = tiltaksdeltakerKafkaRepository.hentForDeltakerId(id)
+            val hendelser = tiltaksdeltakerKafkaRepository.hentForEksternDeltakerId(id)
             hendelser shouldHaveSize 2
             val opprinnelig = tiltaksdeltakerKafkaRepository.hent(opprinneligTiltaksdeltakerHendelse.id)
             opprinnelig shouldNotBe null
@@ -243,7 +243,7 @@ class TiltaksdeltakerServiceTest {
                 objectMapper.writeValueAsString(kometDeltaker),
             )
 
-            tiltaksdeltakerKafkaRepository.hentForDeltakerId(deltakerId.toString()).shouldBeEmpty()
+            tiltaksdeltakerKafkaRepository.hentForEksternDeltakerId(deltakerId.toString()).shouldBeEmpty()
         }
     }
 
@@ -276,7 +276,7 @@ class TiltaksdeltakerServiceTest {
                 objectMapper.writeValueAsString(kometDeltaker),
             )
 
-            val hendelser = tiltaksdeltakerKafkaRepository.hentForDeltakerId(deltakerId.toString())
+            val hendelser = tiltaksdeltakerKafkaRepository.hentForEksternDeltakerId(deltakerId.toString())
             hendelser shouldHaveSize 1
             val tiltaksdeltakerHendelse = hendelser.first()
             tiltaksdeltakerHendelse.deltakelseFraOgMed shouldBe kometDeltaker.startDato
@@ -335,7 +335,7 @@ class TiltaksdeltakerServiceTest {
                 objectMapper.writeValueAsString(kometDeltaker),
             )
 
-            val hendelser = tiltaksdeltakerKafkaRepository.hentForDeltakerId(deltakerId.toString())
+            val hendelser = tiltaksdeltakerKafkaRepository.hentForEksternDeltakerId(deltakerId.toString())
             hendelser shouldHaveSize 2
             val opprinnelig = tiltaksdeltakerKafkaRepository.hent(opprinneligTiltaksdeltakerHendelse.id)
             opprinnelig shouldNotBe null
@@ -368,7 +368,7 @@ class TiltaksdeltakerServiceTest {
                 objectMapper.writeValueAsString(teamTiltakDeltaker),
             )
 
-            tiltaksdeltakerKafkaRepository.hentForDeltakerId(deltakerId).shouldBeEmpty()
+            tiltaksdeltakerKafkaRepository.hentForEksternDeltakerId(deltakerId).shouldBeEmpty()
         }
     }
 
@@ -401,7 +401,7 @@ class TiltaksdeltakerServiceTest {
                 objectMapper.writeValueAsString(teamTiltakDeltaker),
             )
 
-            val hendelser = tiltaksdeltakerKafkaRepository.hentForDeltakerId(deltakerId)
+            val hendelser = tiltaksdeltakerKafkaRepository.hentForEksternDeltakerId(deltakerId)
             hendelser shouldHaveSize 1
             val tiltaksdeltakerHendelse = hendelser.first()
             tiltaksdeltakerHendelse.deltakelseFraOgMed shouldBe teamTiltakDeltaker.startDato
@@ -460,7 +460,7 @@ class TiltaksdeltakerServiceTest {
                 objectMapper.writeValueAsString(teamTiltakDeltaker),
             )
 
-            val hendelser = tiltaksdeltakerKafkaRepository.hentForDeltakerId(deltakerId)
+            val hendelser = tiltaksdeltakerKafkaRepository.hentForEksternDeltakerId(deltakerId)
             hendelser shouldHaveSize 2
             val opprinnelig = tiltaksdeltakerKafkaRepository.hent(opprinneligTiltaksdeltakerHendelse.id)
             opprinnelig shouldNotBe null

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/TiltaksdeltakerServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/TiltaksdeltakerServiceTest.kt
@@ -205,9 +205,8 @@ class TiltaksdeltakerServiceTest {
                 oppgaveSistSjekket = oppgaveSistSjekket,
                 internDeltakerId = soknad.tiltak.tiltaksdeltakerId,
                 behandlingId = null,
-                kilde = TiltaksdeltakerHendelseKilde.Arena,
             )
-            tiltaksdeltakerKafkaRepository.lagre(opprinneligTiltaksdeltakerHendelse, "melding")
+            tiltaksdeltakerKafkaRepository.lagre(opprinneligTiltaksdeltakerHendelse, "melding", TiltaksdeltakerHendelseKilde.Arena)
 
             tiltaksdeltakerService.behandleMottattArenadeltaker(deltakerId, getArenaMeldingString())
 
@@ -328,9 +327,8 @@ class TiltaksdeltakerServiceTest {
                 oppgaveSistSjekket = oppgaveSistSjekket,
                 internDeltakerId = soknad.tiltak.tiltaksdeltakerId,
                 behandlingId = null,
-                kilde = TiltaksdeltakerHendelseKilde.Komet,
             )
-            tiltaksdeltakerKafkaRepository.lagre(opprinneligTiltaksdeltakerHendelse, "melding")
+            tiltaksdeltakerKafkaRepository.lagre(opprinneligTiltaksdeltakerHendelse, "melding", TiltaksdeltakerHendelseKilde.Komet)
 
             tiltaksdeltakerService.behandleMottattKometdeltaker(
                 deltakerId,
@@ -454,9 +452,8 @@ class TiltaksdeltakerServiceTest {
                 oppgaveSistSjekket = oppgaveSistSjekket,
                 internDeltakerId = soknad.tiltak.tiltaksdeltakerId,
                 behandlingId = null,
-                kilde = TiltaksdeltakerHendelseKilde.TeamTiltak,
             )
-            tiltaksdeltakerKafkaRepository.lagre(opprinneligTiltaksdeltakerHendelse, "melding")
+            tiltaksdeltakerKafkaRepository.lagre(opprinneligTiltaksdeltakerHendelse, "melding", TiltaksdeltakerHendelseKilde.TeamTiltak)
 
             tiltaksdeltakerService.behandleMottattTeamTiltakdeltaker(
                 deltakerId,

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/TiltaksdeltakerServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/TiltaksdeltakerServiceTest.kt
@@ -16,6 +16,7 @@ import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.TiltakDeltakerstatu
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.arena.ArenaDeltakerMapper
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelse
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelseId
+import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelseKilde
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.komet.DeltakerV1Dto
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.teamtiltak.AvtaleDto
 import org.junit.jupiter.api.Test
@@ -69,15 +70,15 @@ class TiltaksdeltakerServiceTest {
 
             val hendelser = tiltaksdeltakerKafkaRepository.hentForDeltakerId(id)
             hendelser shouldHaveSize 1
-            val tiltaksdeltakerKafkaDb = hendelser.first()
-            tiltaksdeltakerKafkaDb.deltakelseFraOgMed shouldBe LocalDate.of(2024, 10, 14)
-            tiltaksdeltakerKafkaDb.deltakelseTilOgMed shouldBe LocalDate.of(2025, 8, 10)
-            tiltaksdeltakerKafkaDb.dagerPerUke shouldBe 2.0F
-            tiltaksdeltakerKafkaDb.deltakelsesprosent shouldBe 50.0F
-            tiltaksdeltakerKafkaDb.deltakerstatus shouldBe TiltakDeltakerstatus.Deltar
-            tiltaksdeltakerKafkaDb.sakId shouldBe sak.id
-            tiltaksdeltakerKafkaDb.oppgaveId shouldBe null
-            tiltaksdeltakerKafkaDb.tiltaksdeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
+            val tiltaksdeltakerHendelse = hendelser.first()
+            tiltaksdeltakerHendelse.deltakelseFraOgMed shouldBe LocalDate.of(2024, 10, 14)
+            tiltaksdeltakerHendelse.deltakelseTilOgMed shouldBe LocalDate.of(2025, 8, 10)
+            tiltaksdeltakerHendelse.dagerPerUke shouldBe 2.0F
+            tiltaksdeltakerHendelse.deltakelsesprosent shouldBe 50.0F
+            tiltaksdeltakerHendelse.deltakerstatus shouldBe TiltakDeltakerstatus.Deltar
+            tiltaksdeltakerHendelse.sakId shouldBe sak.id
+            tiltaksdeltakerHendelse.oppgaveId shouldBe null
+            tiltaksdeltakerHendelse.tiltaksdeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
         }
     }
 
@@ -119,15 +120,15 @@ class TiltaksdeltakerServiceTest {
             tiltaksdeltakerKafkaRepository.hentForDeltakerId(id).shouldBeEmpty()
             val hendelser = tiltaksdeltakerKafkaRepository.hentForDeltakerId(nyEksternId.toString())
             hendelser shouldHaveSize 1
-            val tiltaksdeltakerKafkaDb = hendelser.first()
-            tiltaksdeltakerKafkaDb.deltakelseFraOgMed shouldBe LocalDate.of(2024, 10, 14)
-            tiltaksdeltakerKafkaDb.deltakelseTilOgMed shouldBe LocalDate.of(2025, 8, 10)
-            tiltaksdeltakerKafkaDb.dagerPerUke shouldBe 2.0F
-            tiltaksdeltakerKafkaDb.deltakelsesprosent shouldBe 50.0F
-            tiltaksdeltakerKafkaDb.deltakerstatus shouldBe TiltakDeltakerstatus.Deltar
-            tiltaksdeltakerKafkaDb.sakId shouldBe sak.id
-            tiltaksdeltakerKafkaDb.oppgaveId shouldBe null
-            tiltaksdeltakerKafkaDb.tiltaksdeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
+            val tiltaksdeltakerHendelse = hendelser.first()
+            tiltaksdeltakerHendelse.deltakelseFraOgMed shouldBe LocalDate.of(2024, 10, 14)
+            tiltaksdeltakerHendelse.deltakelseTilOgMed shouldBe LocalDate.of(2025, 8, 10)
+            tiltaksdeltakerHendelse.dagerPerUke shouldBe 2.0F
+            tiltaksdeltakerHendelse.deltakelsesprosent shouldBe 50.0F
+            tiltaksdeltakerHendelse.deltakerstatus shouldBe TiltakDeltakerstatus.Deltar
+            tiltaksdeltakerHendelse.sakId shouldBe sak.id
+            tiltaksdeltakerHendelse.oppgaveId shouldBe null
+            tiltaksdeltakerHendelse.tiltaksdeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
         }
     }
 
@@ -204,6 +205,7 @@ class TiltaksdeltakerServiceTest {
                 oppgaveSistSjekket = oppgaveSistSjekket,
                 tiltaksdeltakerId = soknad.tiltak.tiltaksdeltakerId,
                 behandlingId = null,
+                kilde = TiltaksdeltakerHendelseKilde.Arena,
             )
             tiltaksdeltakerKafkaRepository.lagre(opprinneligTiltaksdeltakerHendelse, "melding")
 
@@ -277,15 +279,15 @@ class TiltaksdeltakerServiceTest {
 
             val hendelser = tiltaksdeltakerKafkaRepository.hentForDeltakerId(deltakerId.toString())
             hendelser shouldHaveSize 1
-            val tiltaksdeltakerKafkaDb = hendelser.first()
-            tiltaksdeltakerKafkaDb.deltakelseFraOgMed shouldBe kometDeltaker.startDato
-            tiltaksdeltakerKafkaDb.deltakelseTilOgMed shouldBe kometDeltaker.sluttDato
-            tiltaksdeltakerKafkaDb.dagerPerUke shouldBe kometDeltaker.dagerPerUke
-            tiltaksdeltakerKafkaDb.deltakelsesprosent shouldBe kometDeltaker.prosentStilling
-            tiltaksdeltakerKafkaDb.deltakerstatus shouldBe TiltakDeltakerstatus.Deltar
-            tiltaksdeltakerKafkaDb.sakId shouldBe sak.id
-            tiltaksdeltakerKafkaDb.oppgaveId shouldBe null
-            tiltaksdeltakerKafkaDb.tiltaksdeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
+            val tiltaksdeltakerHendelse = hendelser.first()
+            tiltaksdeltakerHendelse.deltakelseFraOgMed shouldBe kometDeltaker.startDato
+            tiltaksdeltakerHendelse.deltakelseTilOgMed shouldBe kometDeltaker.sluttDato
+            tiltaksdeltakerHendelse.dagerPerUke shouldBe kometDeltaker.dagerPerUke
+            tiltaksdeltakerHendelse.deltakelsesprosent shouldBe kometDeltaker.prosentStilling
+            tiltaksdeltakerHendelse.deltakerstatus shouldBe TiltakDeltakerstatus.Deltar
+            tiltaksdeltakerHendelse.sakId shouldBe sak.id
+            tiltaksdeltakerHendelse.oppgaveId shouldBe null
+            tiltaksdeltakerHendelse.tiltaksdeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
         }
     }
 
@@ -326,6 +328,7 @@ class TiltaksdeltakerServiceTest {
                 oppgaveSistSjekket = oppgaveSistSjekket,
                 tiltaksdeltakerId = soknad.tiltak.tiltaksdeltakerId,
                 behandlingId = null,
+                kilde = TiltaksdeltakerHendelseKilde.Komet,
             )
             tiltaksdeltakerKafkaRepository.lagre(opprinneligTiltaksdeltakerHendelse, "melding")
 
@@ -402,15 +405,15 @@ class TiltaksdeltakerServiceTest {
 
             val hendelser = tiltaksdeltakerKafkaRepository.hentForDeltakerId(deltakerId)
             hendelser shouldHaveSize 1
-            val tiltaksdeltakerKafkaDb = hendelser.first()
-            tiltaksdeltakerKafkaDb.deltakelseFraOgMed shouldBe teamTiltakDeltaker.startDato
-            tiltaksdeltakerKafkaDb.deltakelseTilOgMed shouldBe teamTiltakDeltaker.sluttDato
-            tiltaksdeltakerKafkaDb.dagerPerUke shouldBe teamTiltakDeltaker.antallDagerPerUke?.toFloat()
-            tiltaksdeltakerKafkaDb.deltakelsesprosent shouldBe teamTiltakDeltaker.stillingprosent?.toFloat()
-            tiltaksdeltakerKafkaDb.deltakerstatus shouldBe TiltakDeltakerstatus.Deltar
-            tiltaksdeltakerKafkaDb.sakId shouldBe sak.id
-            tiltaksdeltakerKafkaDb.oppgaveId shouldBe null
-            tiltaksdeltakerKafkaDb.tiltaksdeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
+            val tiltaksdeltakerHendelse = hendelser.first()
+            tiltaksdeltakerHendelse.deltakelseFraOgMed shouldBe teamTiltakDeltaker.startDato
+            tiltaksdeltakerHendelse.deltakelseTilOgMed shouldBe teamTiltakDeltaker.sluttDato
+            tiltaksdeltakerHendelse.dagerPerUke shouldBe teamTiltakDeltaker.antallDagerPerUke?.toFloat()
+            tiltaksdeltakerHendelse.deltakelsesprosent shouldBe teamTiltakDeltaker.stillingprosent?.toFloat()
+            tiltaksdeltakerHendelse.deltakerstatus shouldBe TiltakDeltakerstatus.Deltar
+            tiltaksdeltakerHendelse.sakId shouldBe sak.id
+            tiltaksdeltakerHendelse.oppgaveId shouldBe null
+            tiltaksdeltakerHendelse.tiltaksdeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
         }
     }
 
@@ -451,6 +454,7 @@ class TiltaksdeltakerServiceTest {
                 oppgaveSistSjekket = oppgaveSistSjekket,
                 tiltaksdeltakerId = soknad.tiltak.tiltaksdeltakerId,
                 behandlingId = null,
+                kilde = TiltaksdeltakerHendelseKilde.TeamTiltak,
             )
             tiltaksdeltakerKafkaRepository.lagre(opprinneligTiltaksdeltakerHendelse, "melding")
 

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/TiltaksdeltakerServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/TiltaksdeltakerServiceTest.kt
@@ -78,7 +78,7 @@ class TiltaksdeltakerServiceTest {
             tiltaksdeltakerHendelse.deltakerstatus shouldBe TiltakDeltakerstatus.Deltar
             tiltaksdeltakerHendelse.sakId shouldBe sak.id
             tiltaksdeltakerHendelse.oppgaveId shouldBe null
-            tiltaksdeltakerHendelse.tiltaksdeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
+            tiltaksdeltakerHendelse.internDeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
         }
     }
 
@@ -128,7 +128,7 @@ class TiltaksdeltakerServiceTest {
             tiltaksdeltakerHendelse.deltakerstatus shouldBe TiltakDeltakerstatus.Deltar
             tiltaksdeltakerHendelse.sakId shouldBe sak.id
             tiltaksdeltakerHendelse.oppgaveId shouldBe null
-            tiltaksdeltakerHendelse.tiltaksdeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
+            tiltaksdeltakerHendelse.internDeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
         }
     }
 
@@ -194,7 +194,7 @@ class TiltaksdeltakerServiceTest {
             val oppgaveSistSjekket = nå(testDataHelper.clock)
             val opprinneligTiltaksdeltakerHendelse = TiltaksdeltakerHendelse(
                 id = TiltaksdeltakerHendelseId.random(),
-                deltakerId = id,
+                eksternDeltakerId = id,
                 deltakelseFraOgMed = LocalDate.of(2024, 10, 14),
                 deltakelseTilOgMed = LocalDate.of(2025, 1, 10),
                 dagerPerUke = 3.0F,
@@ -203,7 +203,7 @@ class TiltaksdeltakerServiceTest {
                 sakId = sak.id,
                 oppgaveId = ObjectMother.oppgaveId(),
                 oppgaveSistSjekket = oppgaveSistSjekket,
-                tiltaksdeltakerId = soknad.tiltak.tiltaksdeltakerId,
+                internDeltakerId = soknad.tiltak.tiltaksdeltakerId,
                 behandlingId = null,
                 kilde = TiltaksdeltakerHendelseKilde.Arena,
             )
@@ -224,7 +224,7 @@ class TiltaksdeltakerServiceTest {
             nyHendelse.deltakerstatus shouldBe TiltakDeltakerstatus.Deltar
             nyHendelse.sakId shouldBe sak.id
             nyHendelse.oppgaveId shouldBe null
-            nyHendelse.tiltaksdeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
+            nyHendelse.internDeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
         }
     }
 
@@ -287,7 +287,7 @@ class TiltaksdeltakerServiceTest {
             tiltaksdeltakerHendelse.deltakerstatus shouldBe TiltakDeltakerstatus.Deltar
             tiltaksdeltakerHendelse.sakId shouldBe sak.id
             tiltaksdeltakerHendelse.oppgaveId shouldBe null
-            tiltaksdeltakerHendelse.tiltaksdeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
+            tiltaksdeltakerHendelse.internDeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
         }
     }
 
@@ -317,7 +317,7 @@ class TiltaksdeltakerServiceTest {
             val oppgaveSistSjekket = nå(testDataHelper.clock)
             val opprinneligTiltaksdeltakerHendelse = TiltaksdeltakerHendelse(
                 id = TiltaksdeltakerHendelseId.random(),
-                deltakerId = deltakerId.toString(),
+                eksternDeltakerId = deltakerId.toString(),
                 deltakelseFraOgMed = LocalDate.of(2024, 10, 14),
                 deltakelseTilOgMed = LocalDate.of(2025, 1, 10),
                 dagerPerUke = 3.0F,
@@ -326,7 +326,7 @@ class TiltaksdeltakerServiceTest {
                 sakId = sak.id,
                 oppgaveId = ObjectMother.oppgaveId(),
                 oppgaveSistSjekket = oppgaveSistSjekket,
-                tiltaksdeltakerId = soknad.tiltak.tiltaksdeltakerId,
+                internDeltakerId = soknad.tiltak.tiltaksdeltakerId,
                 behandlingId = null,
                 kilde = TiltaksdeltakerHendelseKilde.Komet,
             )
@@ -350,7 +350,7 @@ class TiltaksdeltakerServiceTest {
             nyHendelse.deltakerstatus shouldBe TiltakDeltakerstatus.Deltar
             nyHendelse.sakId shouldBe sak.id
             nyHendelse.oppgaveId shouldBe null
-            nyHendelse.tiltaksdeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
+            nyHendelse.internDeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
         }
     }
 
@@ -413,7 +413,7 @@ class TiltaksdeltakerServiceTest {
             tiltaksdeltakerHendelse.deltakerstatus shouldBe TiltakDeltakerstatus.Deltar
             tiltaksdeltakerHendelse.sakId shouldBe sak.id
             tiltaksdeltakerHendelse.oppgaveId shouldBe null
-            tiltaksdeltakerHendelse.tiltaksdeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
+            tiltaksdeltakerHendelse.internDeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
         }
     }
 
@@ -443,7 +443,7 @@ class TiltaksdeltakerServiceTest {
             val oppgaveSistSjekket = nå(testDataHelper.clock)
             val opprinneligTiltaksdeltakerHendelse = TiltaksdeltakerHendelse(
                 id = TiltaksdeltakerHendelseId.random(),
-                deltakerId = deltakerId,
+                eksternDeltakerId = deltakerId,
                 deltakelseFraOgMed = LocalDate.of(2024, 10, 14),
                 deltakelseTilOgMed = LocalDate.of(2025, 1, 10),
                 dagerPerUke = 3.0F,
@@ -452,7 +452,7 @@ class TiltaksdeltakerServiceTest {
                 sakId = sak.id,
                 oppgaveId = ObjectMother.oppgaveId(),
                 oppgaveSistSjekket = oppgaveSistSjekket,
-                tiltaksdeltakerId = soknad.tiltak.tiltaksdeltakerId,
+                internDeltakerId = soknad.tiltak.tiltaksdeltakerId,
                 behandlingId = null,
                 kilde = TiltaksdeltakerHendelseKilde.TeamTiltak,
             )
@@ -476,7 +476,7 @@ class TiltaksdeltakerServiceTest {
             nyHendelse.deltakerstatus shouldBe TiltakDeltakerstatus.Deltar
             nyHendelse.sakId shouldBe sak.id
             nyHendelse.oppgaveId shouldBe null
-            nyHendelse.tiltaksdeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
+            nyHendelse.internDeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
         }
     }
 

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/TiltaksdeltakerServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/TiltaksdeltakerServiceTest.kt
@@ -1,5 +1,7 @@
 package no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka
 
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import no.nav.tiltakspenger.libs.common.Fnr
@@ -12,12 +14,12 @@ import no.nav.tiltakspenger.saksbehandling.infra.repo.withMigratedDb
 import no.nav.tiltakspenger.saksbehandling.objectmothers.ObjectMother
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.TiltakDeltakerstatus
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.arena.ArenaDeltakerMapper
+import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelse
+import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelseId
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.komet.DeltakerV1Dto
-import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.repository.TiltaksdeltakerKafkaDb
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.teamtiltak.AvtaleDto
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
-import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 class TiltaksdeltakerServiceTest {
@@ -26,7 +28,7 @@ class TiltaksdeltakerServiceTest {
     @Test
     fun `behandleMottattArenadeltaker - finnes ingen sak - ignorerer`() {
         withMigratedDb(runIsolated = true) { testDataHelper ->
-            val tiltaksdeltakerKafkaRepository = testDataHelper.tiltaksdeltakerKafkaRepository
+            val tiltaksdeltakerKafkaRepository = testDataHelper.tiltaksdeltakerHendelsePostgresRepo
             val soknadRepo = testDataHelper.søknadRepo
             val tiltaksdeltakerRepo = testDataHelper.tiltaksdeltakerRepo
             val tiltaksdeltakerService =
@@ -35,14 +37,14 @@ class TiltaksdeltakerServiceTest {
 
             tiltaksdeltakerService.behandleMottattArenadeltaker(deltakerId, getArenaMeldingString())
 
-            tiltaksdeltakerKafkaRepository.hent(deltakerId) shouldBe null
+            tiltaksdeltakerKafkaRepository.hentForDeltakerId(deltakerId).shouldBeEmpty()
         }
     }
 
     @Test
     fun `behandleMottattArenadeltaker - finnes sak, ikke lagret melding - lagrer`() {
         withMigratedDb(runIsolated = true) { testDataHelper ->
-            val tiltaksdeltakerKafkaRepository = testDataHelper.tiltaksdeltakerKafkaRepository
+            val tiltaksdeltakerKafkaRepository = testDataHelper.tiltaksdeltakerHendelsePostgresRepo
             val soknadRepo = testDataHelper.søknadRepo
             val tiltaksdeltakerRepo = testDataHelper.tiltaksdeltakerRepo
             val tiltaksdeltakerService =
@@ -65,23 +67,24 @@ class TiltaksdeltakerServiceTest {
 
             tiltaksdeltakerService.behandleMottattArenadeltaker(deltakerId, getArenaMeldingString())
 
-            val tiltaksdeltakerKafkaDb = tiltaksdeltakerKafkaRepository.hent(id)
-            tiltaksdeltakerKafkaDb shouldNotBe null
-            tiltaksdeltakerKafkaDb?.deltakelseFraOgMed shouldBe LocalDate.of(2024, 10, 14)
-            tiltaksdeltakerKafkaDb?.deltakelseTilOgMed shouldBe LocalDate.of(2025, 8, 10)
-            tiltaksdeltakerKafkaDb?.dagerPerUke shouldBe 2.0F
-            tiltaksdeltakerKafkaDb?.deltakelsesprosent shouldBe 50.0F
-            tiltaksdeltakerKafkaDb?.deltakerstatus shouldBe TiltakDeltakerstatus.Deltar
-            tiltaksdeltakerKafkaDb?.sakId shouldBe sak.id
-            tiltaksdeltakerKafkaDb?.oppgaveId shouldBe null
-            tiltaksdeltakerKafkaDb?.tiltaksdeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
+            val hendelser = tiltaksdeltakerKafkaRepository.hentForDeltakerId(id)
+            hendelser shouldHaveSize 1
+            val tiltaksdeltakerKafkaDb = hendelser.first()
+            tiltaksdeltakerKafkaDb.deltakelseFraOgMed shouldBe LocalDate.of(2024, 10, 14)
+            tiltaksdeltakerKafkaDb.deltakelseTilOgMed shouldBe LocalDate.of(2025, 8, 10)
+            tiltaksdeltakerKafkaDb.dagerPerUke shouldBe 2.0F
+            tiltaksdeltakerKafkaDb.deltakelsesprosent shouldBe 50.0F
+            tiltaksdeltakerKafkaDb.deltakerstatus shouldBe TiltakDeltakerstatus.Deltar
+            tiltaksdeltakerKafkaDb.sakId shouldBe sak.id
+            tiltaksdeltakerKafkaDb.oppgaveId shouldBe null
+            tiltaksdeltakerKafkaDb.tiltaksdeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
         }
     }
 
     @Test
     fun `behandleMottattArenadeltaker - finnes sak, har eksternId - oppdaterer eksternId og lagrer`() {
         withMigratedDb(runIsolated = true) { testDataHelper ->
-            val tiltaksdeltakerKafkaRepository = testDataHelper.tiltaksdeltakerKafkaRepository
+            val tiltaksdeltakerKafkaRepository = testDataHelper.tiltaksdeltakerHendelsePostgresRepo
             val soknadRepo = testDataHelper.søknadRepo
             val tiltaksdeltakerRepo = testDataHelper.tiltaksdeltakerRepo
             val tiltaksdeltakerService =
@@ -113,24 +116,25 @@ class TiltaksdeltakerServiceTest {
             oppdatertTiltaksdeltaker?.tiltakstype shouldBe soknadstiltak.typeKode
             oppdatertTiltaksdeltaker?.utdatertEksternId shouldBe id
 
-            tiltaksdeltakerKafkaRepository.hent(id) shouldBe null
-            val tiltaksdeltakerKafkaDb = tiltaksdeltakerKafkaRepository.hent(nyEksternId.toString())
-            tiltaksdeltakerKafkaDb shouldNotBe null
-            tiltaksdeltakerKafkaDb?.deltakelseFraOgMed shouldBe LocalDate.of(2024, 10, 14)
-            tiltaksdeltakerKafkaDb?.deltakelseTilOgMed shouldBe LocalDate.of(2025, 8, 10)
-            tiltaksdeltakerKafkaDb?.dagerPerUke shouldBe 2.0F
-            tiltaksdeltakerKafkaDb?.deltakelsesprosent shouldBe 50.0F
-            tiltaksdeltakerKafkaDb?.deltakerstatus shouldBe TiltakDeltakerstatus.Deltar
-            tiltaksdeltakerKafkaDb?.sakId shouldBe sak.id
-            tiltaksdeltakerKafkaDb?.oppgaveId shouldBe null
-            tiltaksdeltakerKafkaDb?.tiltaksdeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
+            tiltaksdeltakerKafkaRepository.hentForDeltakerId(id).shouldBeEmpty()
+            val hendelser = tiltaksdeltakerKafkaRepository.hentForDeltakerId(nyEksternId.toString())
+            hendelser shouldHaveSize 1
+            val tiltaksdeltakerKafkaDb = hendelser.first()
+            tiltaksdeltakerKafkaDb.deltakelseFraOgMed shouldBe LocalDate.of(2024, 10, 14)
+            tiltaksdeltakerKafkaDb.deltakelseTilOgMed shouldBe LocalDate.of(2025, 8, 10)
+            tiltaksdeltakerKafkaDb.dagerPerUke shouldBe 2.0F
+            tiltaksdeltakerKafkaDb.deltakelsesprosent shouldBe 50.0F
+            tiltaksdeltakerKafkaDb.deltakerstatus shouldBe TiltakDeltakerstatus.Deltar
+            tiltaksdeltakerKafkaDb.sakId shouldBe sak.id
+            tiltaksdeltakerKafkaDb.oppgaveId shouldBe null
+            tiltaksdeltakerKafkaDb.tiltaksdeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
         }
     }
 
     @Test
     fun `behandleMottattArenadeltaker - finnes sak for arena-eksternId - lagrer ikke`() {
         withMigratedDb(runIsolated = true) { testDataHelper ->
-            val tiltaksdeltakerKafkaRepository = testDataHelper.tiltaksdeltakerKafkaRepository
+            val tiltaksdeltakerKafkaRepository = testDataHelper.tiltaksdeltakerHendelsePostgresRepo
             val soknadRepo = testDataHelper.søknadRepo
             val tiltaksdeltakerRepo = testDataHelper.tiltaksdeltakerRepo
             val tiltaksdeltakerService =
@@ -158,15 +162,15 @@ class TiltaksdeltakerServiceTest {
             tiltaksdeltakerRepo.hentTiltaksdeltaker(nyEksternId.toString()) shouldNotBe null
             tiltaksdeltakerRepo.hentTiltaksdeltaker(id) shouldBe null
 
-            tiltaksdeltakerKafkaRepository.hent(nyEksternId.toString()) shouldBe null
-            tiltaksdeltakerKafkaRepository.hent(id) shouldBe null
+            tiltaksdeltakerKafkaRepository.hentForDeltakerId(nyEksternId.toString()).shouldBeEmpty()
+            tiltaksdeltakerKafkaRepository.hentForDeltakerId(id).shouldBeEmpty()
         }
     }
 
     @Test
-    fun `behandleMottattArenadeltaker - finnes sak og melding med oppgaveId - lagrer og beholder oppgaveId`() {
+    fun `behandleMottattArenadeltaker - finnes sak og melding med oppgaveId - lagrer ny hendelse uavhengig av eksisterende`() {
         withMigratedDb(runIsolated = true) { testDataHelper ->
-            val tiltaksdeltakerKafkaRepository = testDataHelper.tiltaksdeltakerKafkaRepository
+            val tiltaksdeltakerKafkaRepository = testDataHelper.tiltaksdeltakerHendelsePostgresRepo
             val soknadRepo = testDataHelper.søknadRepo
             val tiltaksdeltakerRepo = testDataHelper.tiltaksdeltakerRepo
             val tiltaksdeltakerService =
@@ -187,8 +191,9 @@ class TiltaksdeltakerServiceTest {
                 søknad = soknad,
             )
             val oppgaveSistSjekket = nå(testDataHelper.clock)
-            val opprinneligTiltaksdeltakerKafkaDb = TiltaksdeltakerKafkaDb(
-                id = id,
+            val opprinneligTiltaksdeltakerHendelse = TiltaksdeltakerHendelse(
+                id = TiltaksdeltakerHendelseId.random(),
+                deltakerId = id,
                 deltakelseFraOgMed = LocalDate.of(2024, 10, 14),
                 deltakelseTilOgMed = LocalDate.of(2025, 1, 10),
                 dagerPerUke = 3.0F,
@@ -200,30 +205,31 @@ class TiltaksdeltakerServiceTest {
                 tiltaksdeltakerId = soknad.tiltak.tiltaksdeltakerId,
                 behandlingId = null,
             )
-            tiltaksdeltakerKafkaRepository.lagre(opprinneligTiltaksdeltakerKafkaDb, "melding")
+            tiltaksdeltakerKafkaRepository.lagre(opprinneligTiltaksdeltakerHendelse, "melding")
 
             tiltaksdeltakerService.behandleMottattArenadeltaker(deltakerId, getArenaMeldingString())
 
-            val tiltaksdeltakerKafkaDb = tiltaksdeltakerKafkaRepository.hent(id)
-            tiltaksdeltakerKafkaDb shouldNotBe null
-            tiltaksdeltakerKafkaDb?.deltakelseFraOgMed shouldBe LocalDate.of(2024, 10, 14)
-            tiltaksdeltakerKafkaDb?.deltakelseTilOgMed shouldBe LocalDate.of(2025, 8, 10)
-            tiltaksdeltakerKafkaDb?.dagerPerUke shouldBe 2.0F
-            tiltaksdeltakerKafkaDb?.deltakelsesprosent shouldBe 50.0F
-            tiltaksdeltakerKafkaDb?.deltakerstatus shouldBe TiltakDeltakerstatus.Deltar
-            tiltaksdeltakerKafkaDb?.sakId shouldBe sak.id
-            tiltaksdeltakerKafkaDb?.oppgaveId shouldBe opprinneligTiltaksdeltakerKafkaDb.oppgaveId
-            tiltaksdeltakerKafkaDb?.oppgaveSistSjekket?.truncatedTo(ChronoUnit.MINUTES) shouldBe oppgaveSistSjekket.truncatedTo(
-                ChronoUnit.MINUTES,
-            )
-            tiltaksdeltakerKafkaDb?.tiltaksdeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
+            val hendelser = tiltaksdeltakerKafkaRepository.hentForDeltakerId(id)
+            hendelser shouldHaveSize 2
+            val opprinnelig = tiltaksdeltakerKafkaRepository.hent(opprinneligTiltaksdeltakerHendelse.id)
+            opprinnelig shouldNotBe null
+            opprinnelig?.oppgaveId shouldBe opprinneligTiltaksdeltakerHendelse.oppgaveId
+            val nyHendelse = hendelser.first { it.id != opprinneligTiltaksdeltakerHendelse.id }
+            nyHendelse.deltakelseFraOgMed shouldBe LocalDate.of(2024, 10, 14)
+            nyHendelse.deltakelseTilOgMed shouldBe LocalDate.of(2025, 8, 10)
+            nyHendelse.dagerPerUke shouldBe 2.0F
+            nyHendelse.deltakelsesprosent shouldBe 50.0F
+            nyHendelse.deltakerstatus shouldBe TiltakDeltakerstatus.Deltar
+            nyHendelse.sakId shouldBe sak.id
+            nyHendelse.oppgaveId shouldBe null
+            nyHendelse.tiltaksdeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
         }
     }
 
     @Test
     fun `behandleMottattKometdeltaker - finnes ingen sak - ignorerer`() {
         withMigratedDb(runIsolated = true) { testDataHelper ->
-            val tiltaksdeltakerKafkaRepository = testDataHelper.tiltaksdeltakerKafkaRepository
+            val tiltaksdeltakerKafkaRepository = testDataHelper.tiltaksdeltakerHendelsePostgresRepo
             val soknadRepo = testDataHelper.søknadRepo
             val tiltaksdeltakerRepo = testDataHelper.tiltaksdeltakerRepo
             val tiltaksdeltakerService =
@@ -236,14 +242,14 @@ class TiltaksdeltakerServiceTest {
                 objectMapper.writeValueAsString(kometDeltaker),
             )
 
-            tiltaksdeltakerKafkaRepository.hent(deltakerId.toString()) shouldBe null
+            tiltaksdeltakerKafkaRepository.hentForDeltakerId(deltakerId.toString()).shouldBeEmpty()
         }
     }
 
     @Test
     fun `behandleMottattKometdeltaker - finnes sak, ikke lagret melding - lagrer`() {
         withMigratedDb(runIsolated = true) { testDataHelper ->
-            val tiltaksdeltakerKafkaRepository = testDataHelper.tiltaksdeltakerKafkaRepository
+            val tiltaksdeltakerKafkaRepository = testDataHelper.tiltaksdeltakerHendelsePostgresRepo
             val soknadRepo = testDataHelper.søknadRepo
             val tiltaksdeltakerRepo = testDataHelper.tiltaksdeltakerRepo
             val tiltaksdeltakerService =
@@ -269,23 +275,24 @@ class TiltaksdeltakerServiceTest {
                 objectMapper.writeValueAsString(kometDeltaker),
             )
 
-            val tiltaksdeltakerKafkaDb = tiltaksdeltakerKafkaRepository.hent(deltakerId.toString())
-            tiltaksdeltakerKafkaDb shouldNotBe null
-            tiltaksdeltakerKafkaDb?.deltakelseFraOgMed shouldBe kometDeltaker.startDato
-            tiltaksdeltakerKafkaDb?.deltakelseTilOgMed shouldBe kometDeltaker.sluttDato
-            tiltaksdeltakerKafkaDb?.dagerPerUke shouldBe kometDeltaker.dagerPerUke
-            tiltaksdeltakerKafkaDb?.deltakelsesprosent shouldBe kometDeltaker.prosentStilling
-            tiltaksdeltakerKafkaDb?.deltakerstatus shouldBe TiltakDeltakerstatus.Deltar
-            tiltaksdeltakerKafkaDb?.sakId shouldBe sak.id
-            tiltaksdeltakerKafkaDb?.oppgaveId shouldBe null
-            tiltaksdeltakerKafkaDb?.tiltaksdeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
+            val hendelser = tiltaksdeltakerKafkaRepository.hentForDeltakerId(deltakerId.toString())
+            hendelser shouldHaveSize 1
+            val tiltaksdeltakerKafkaDb = hendelser.first()
+            tiltaksdeltakerKafkaDb.deltakelseFraOgMed shouldBe kometDeltaker.startDato
+            tiltaksdeltakerKafkaDb.deltakelseTilOgMed shouldBe kometDeltaker.sluttDato
+            tiltaksdeltakerKafkaDb.dagerPerUke shouldBe kometDeltaker.dagerPerUke
+            tiltaksdeltakerKafkaDb.deltakelsesprosent shouldBe kometDeltaker.prosentStilling
+            tiltaksdeltakerKafkaDb.deltakerstatus shouldBe TiltakDeltakerstatus.Deltar
+            tiltaksdeltakerKafkaDb.sakId shouldBe sak.id
+            tiltaksdeltakerKafkaDb.oppgaveId shouldBe null
+            tiltaksdeltakerKafkaDb.tiltaksdeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
         }
     }
 
     @Test
-    fun `behandleMottattKometdeltaker - finnes sak og melding med oppgaveId - lagrer og beholder oppgaveId`() {
+    fun `behandleMottattKometdeltaker - finnes sak og melding med oppgaveId - lagrer ny hendelse uavhengig av eksisterende`() {
         withMigratedDb(runIsolated = true) { testDataHelper ->
-            val tiltaksdeltakerKafkaRepository = testDataHelper.tiltaksdeltakerKafkaRepository
+            val tiltaksdeltakerKafkaRepository = testDataHelper.tiltaksdeltakerHendelsePostgresRepo
             val soknadRepo = testDataHelper.søknadRepo
             val tiltaksdeltakerRepo = testDataHelper.tiltaksdeltakerRepo
             val tiltaksdeltakerService =
@@ -306,8 +313,9 @@ class TiltaksdeltakerServiceTest {
                 søknad = soknad,
             )
             val oppgaveSistSjekket = nå(testDataHelper.clock)
-            val opprinneligTiltaksdeltakerKafkaDb = TiltaksdeltakerKafkaDb(
-                id = deltakerId.toString(),
+            val opprinneligTiltaksdeltakerHendelse = TiltaksdeltakerHendelse(
+                id = TiltaksdeltakerHendelseId.random(),
+                deltakerId = deltakerId.toString(),
                 deltakelseFraOgMed = LocalDate.of(2024, 10, 14),
                 deltakelseTilOgMed = LocalDate.of(2025, 1, 10),
                 dagerPerUke = 3.0F,
@@ -319,33 +327,34 @@ class TiltaksdeltakerServiceTest {
                 tiltaksdeltakerId = soknad.tiltak.tiltaksdeltakerId,
                 behandlingId = null,
             )
-            tiltaksdeltakerKafkaRepository.lagre(opprinneligTiltaksdeltakerKafkaDb, "melding")
+            tiltaksdeltakerKafkaRepository.lagre(opprinneligTiltaksdeltakerHendelse, "melding")
 
             tiltaksdeltakerService.behandleMottattKometdeltaker(
                 deltakerId,
                 objectMapper.writeValueAsString(kometDeltaker),
             )
 
-            val tiltaksdeltakerKafkaDb = tiltaksdeltakerKafkaRepository.hent(deltakerId.toString())
-            tiltaksdeltakerKafkaDb shouldNotBe null
-            tiltaksdeltakerKafkaDb?.deltakelseFraOgMed shouldBe kometDeltaker.startDato
-            tiltaksdeltakerKafkaDb?.deltakelseTilOgMed shouldBe kometDeltaker.sluttDato
-            tiltaksdeltakerKafkaDb?.dagerPerUke shouldBe kometDeltaker.dagerPerUke
-            tiltaksdeltakerKafkaDb?.deltakelsesprosent shouldBe kometDeltaker.prosentStilling
-            tiltaksdeltakerKafkaDb?.deltakerstatus shouldBe TiltakDeltakerstatus.Deltar
-            tiltaksdeltakerKafkaDb?.sakId shouldBe sak.id
-            tiltaksdeltakerKafkaDb?.oppgaveId shouldBe opprinneligTiltaksdeltakerKafkaDb.oppgaveId
-            tiltaksdeltakerKafkaDb?.oppgaveSistSjekket?.truncatedTo(ChronoUnit.MINUTES) shouldBe oppgaveSistSjekket.truncatedTo(
-                ChronoUnit.MINUTES,
-            )
-            tiltaksdeltakerKafkaDb?.tiltaksdeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
+            val hendelser = tiltaksdeltakerKafkaRepository.hentForDeltakerId(deltakerId.toString())
+            hendelser shouldHaveSize 2
+            val opprinnelig = tiltaksdeltakerKafkaRepository.hent(opprinneligTiltaksdeltakerHendelse.id)
+            opprinnelig shouldNotBe null
+            opprinnelig?.oppgaveId shouldBe opprinneligTiltaksdeltakerHendelse.oppgaveId
+            val nyHendelse = hendelser.first { it.id != opprinneligTiltaksdeltakerHendelse.id }
+            nyHendelse.deltakelseFraOgMed shouldBe kometDeltaker.startDato
+            nyHendelse.deltakelseTilOgMed shouldBe kometDeltaker.sluttDato
+            nyHendelse.dagerPerUke shouldBe kometDeltaker.dagerPerUke
+            nyHendelse.deltakelsesprosent shouldBe kometDeltaker.prosentStilling
+            nyHendelse.deltakerstatus shouldBe TiltakDeltakerstatus.Deltar
+            nyHendelse.sakId shouldBe sak.id
+            nyHendelse.oppgaveId shouldBe null
+            nyHendelse.tiltaksdeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
         }
     }
 
     @Test
     fun `behandleMottattTeamTiltakdeltaker - finnes ingen sak - ignorerer`() {
         withMigratedDb(runIsolated = true) { testDataHelper ->
-            val tiltaksdeltakerKafkaRepository = testDataHelper.tiltaksdeltakerKafkaRepository
+            val tiltaksdeltakerKafkaRepository = testDataHelper.tiltaksdeltakerHendelsePostgresRepo
             val soknadRepo = testDataHelper.søknadRepo
             val tiltaksdeltakerRepo = testDataHelper.tiltaksdeltakerRepo
             val tiltaksdeltakerService =
@@ -358,14 +367,14 @@ class TiltaksdeltakerServiceTest {
                 objectMapper.writeValueAsString(teamTiltakDeltaker),
             )
 
-            tiltaksdeltakerKafkaRepository.hent(deltakerId) shouldBe null
+            tiltaksdeltakerKafkaRepository.hentForDeltakerId(deltakerId).shouldBeEmpty()
         }
     }
 
     @Test
     fun `behandleMottattTeamTiltakdeltaker - finnes sak, ikke lagret melding - lagrer`() {
         withMigratedDb(runIsolated = true) { testDataHelper ->
-            val tiltaksdeltakerKafkaRepository = testDataHelper.tiltaksdeltakerKafkaRepository
+            val tiltaksdeltakerKafkaRepository = testDataHelper.tiltaksdeltakerHendelsePostgresRepo
             val soknadRepo = testDataHelper.søknadRepo
             val tiltaksdeltakerRepo = testDataHelper.tiltaksdeltakerRepo
             val tiltaksdeltakerService =
@@ -391,23 +400,24 @@ class TiltaksdeltakerServiceTest {
                 objectMapper.writeValueAsString(teamTiltakDeltaker),
             )
 
-            val tiltaksdeltakerKafkaDb = tiltaksdeltakerKafkaRepository.hent(deltakerId)
-            tiltaksdeltakerKafkaDb shouldNotBe null
-            tiltaksdeltakerKafkaDb?.deltakelseFraOgMed shouldBe teamTiltakDeltaker.startDato
-            tiltaksdeltakerKafkaDb?.deltakelseTilOgMed shouldBe teamTiltakDeltaker.sluttDato
-            tiltaksdeltakerKafkaDb?.dagerPerUke shouldBe teamTiltakDeltaker.antallDagerPerUke?.toFloat()
-            tiltaksdeltakerKafkaDb?.deltakelsesprosent shouldBe teamTiltakDeltaker.stillingprosent?.toFloat()
-            tiltaksdeltakerKafkaDb?.deltakerstatus shouldBe TiltakDeltakerstatus.Deltar
-            tiltaksdeltakerKafkaDb?.sakId shouldBe sak.id
-            tiltaksdeltakerKafkaDb?.oppgaveId shouldBe null
-            tiltaksdeltakerKafkaDb?.tiltaksdeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
+            val hendelser = tiltaksdeltakerKafkaRepository.hentForDeltakerId(deltakerId)
+            hendelser shouldHaveSize 1
+            val tiltaksdeltakerKafkaDb = hendelser.first()
+            tiltaksdeltakerKafkaDb.deltakelseFraOgMed shouldBe teamTiltakDeltaker.startDato
+            tiltaksdeltakerKafkaDb.deltakelseTilOgMed shouldBe teamTiltakDeltaker.sluttDato
+            tiltaksdeltakerKafkaDb.dagerPerUke shouldBe teamTiltakDeltaker.antallDagerPerUke?.toFloat()
+            tiltaksdeltakerKafkaDb.deltakelsesprosent shouldBe teamTiltakDeltaker.stillingprosent?.toFloat()
+            tiltaksdeltakerKafkaDb.deltakerstatus shouldBe TiltakDeltakerstatus.Deltar
+            tiltaksdeltakerKafkaDb.sakId shouldBe sak.id
+            tiltaksdeltakerKafkaDb.oppgaveId shouldBe null
+            tiltaksdeltakerKafkaDb.tiltaksdeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
         }
     }
 
     @Test
-    fun `behandleMottattTeamTiltakdeltaker - finnes sak og melding med oppgaveId - lagrer og beholder oppgaveId`() {
+    fun `behandleMottattTeamTiltakdeltaker - finnes sak og melding med oppgaveId - lagrer ny hendelse uavhengig av eksisterende`() {
         withMigratedDb(runIsolated = true) { testDataHelper ->
-            val tiltaksdeltakerKafkaRepository = testDataHelper.tiltaksdeltakerKafkaRepository
+            val tiltaksdeltakerKafkaRepository = testDataHelper.tiltaksdeltakerHendelsePostgresRepo
             val soknadRepo = testDataHelper.søknadRepo
             val tiltaksdeltakerRepo = testDataHelper.tiltaksdeltakerRepo
             val tiltaksdeltakerService =
@@ -428,8 +438,9 @@ class TiltaksdeltakerServiceTest {
                 søknad = soknad,
             )
             val oppgaveSistSjekket = nå(testDataHelper.clock)
-            val opprinneligTiltaksdeltakerKafkaDb = TiltaksdeltakerKafkaDb(
-                id = deltakerId,
+            val opprinneligTiltaksdeltakerHendelse = TiltaksdeltakerHendelse(
+                id = TiltaksdeltakerHendelseId.random(),
+                deltakerId = deltakerId,
                 deltakelseFraOgMed = LocalDate.of(2024, 10, 14),
                 deltakelseTilOgMed = LocalDate.of(2025, 1, 10),
                 dagerPerUke = 3.0F,
@@ -441,26 +452,27 @@ class TiltaksdeltakerServiceTest {
                 tiltaksdeltakerId = soknad.tiltak.tiltaksdeltakerId,
                 behandlingId = null,
             )
-            tiltaksdeltakerKafkaRepository.lagre(opprinneligTiltaksdeltakerKafkaDb, "melding")
+            tiltaksdeltakerKafkaRepository.lagre(opprinneligTiltaksdeltakerHendelse, "melding")
 
             tiltaksdeltakerService.behandleMottattTeamTiltakdeltaker(
                 deltakerId,
                 objectMapper.writeValueAsString(teamTiltakDeltaker),
             )
 
-            val tiltaksdeltakerKafkaDb = tiltaksdeltakerKafkaRepository.hent(deltakerId)
-            tiltaksdeltakerKafkaDb shouldNotBe null
-            tiltaksdeltakerKafkaDb?.deltakelseFraOgMed shouldBe teamTiltakDeltaker.startDato
-            tiltaksdeltakerKafkaDb?.deltakelseTilOgMed shouldBe teamTiltakDeltaker.sluttDato
-            tiltaksdeltakerKafkaDb?.dagerPerUke shouldBe teamTiltakDeltaker.antallDagerPerUke?.toFloat()
-            tiltaksdeltakerKafkaDb?.deltakelsesprosent shouldBe teamTiltakDeltaker.stillingprosent?.toFloat()
-            tiltaksdeltakerKafkaDb?.deltakerstatus shouldBe TiltakDeltakerstatus.Deltar
-            tiltaksdeltakerKafkaDb?.sakId shouldBe sak.id
-            tiltaksdeltakerKafkaDb?.oppgaveId shouldBe opprinneligTiltaksdeltakerKafkaDb.oppgaveId
-            tiltaksdeltakerKafkaDb?.oppgaveSistSjekket?.truncatedTo(ChronoUnit.MINUTES) shouldBe oppgaveSistSjekket.truncatedTo(
-                ChronoUnit.MINUTES,
-            )
-            tiltaksdeltakerKafkaDb?.tiltaksdeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
+            val hendelser = tiltaksdeltakerKafkaRepository.hentForDeltakerId(deltakerId)
+            hendelser shouldHaveSize 2
+            val opprinnelig = tiltaksdeltakerKafkaRepository.hent(opprinneligTiltaksdeltakerHendelse.id)
+            opprinnelig shouldNotBe null
+            opprinnelig?.oppgaveId shouldBe opprinneligTiltaksdeltakerHendelse.oppgaveId
+            val nyHendelse = hendelser.first { it.id != opprinneligTiltaksdeltakerHendelse.id }
+            nyHendelse.deltakelseFraOgMed shouldBe teamTiltakDeltaker.startDato
+            nyHendelse.deltakelseTilOgMed shouldBe teamTiltakDeltaker.sluttDato
+            nyHendelse.dagerPerUke shouldBe teamTiltakDeltaker.antallDagerPerUke?.toFloat()
+            nyHendelse.deltakelsesprosent shouldBe teamTiltakDeltaker.stillingprosent?.toFloat()
+            nyHendelse.deltakerstatus shouldBe TiltakDeltakerstatus.Deltar
+            nyHendelse.sakId shouldBe sak.id
+            nyHendelse.oppgaveId shouldBe null
+            nyHendelse.tiltaksdeltakerId shouldBe soknad.tiltak.tiltaksdeltakerId
         }
     }
 

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/jobb/EndretTiltaksdeltakerJobbTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/jobb/EndretTiltaksdeltakerJobbTest.kt
@@ -43,6 +43,58 @@ class EndretTiltaksdeltakerJobbTest {
     private val oppgaveId = oppgaveId()
 
     @Test
+    fun `hendelser innenfor forsinkelsesvinduet blir ikke behandlet`() {
+        withTestApplicationContextAndPostgres(runIsolated = true) { tac ->
+            val fnr = Fnr.random()
+            val tiltaksdeltakerId = TiltaksdeltakerId.random()
+            val deltakelseFom = 5.januar(2025)
+            val deltakelsesTom = 5.mai(2025)
+            val deltakelsesperiode = deltakelseFom til deltakelsesTom
+
+            val tiltaksdeltakelse = tiltaksdeltakelse(
+                periode = deltakelsesperiode,
+                internDeltakelseId = tiltaksdeltakerId,
+            )
+
+            val (sak) = iverksettSøknadsbehandling(
+                tac = tac,
+                fnr = fnr,
+                innvilgelsesperioder = innvilgelsesperioder(deltakelsesperiode, tiltaksdeltakelse),
+                tiltaksdeltakelse = tiltaksdeltakelse,
+            )
+
+            // Hendelse innenfor forsinkelsesvinduet (10 min siden, vindu er 15 min)
+            val nyligHendelse = getTiltaksdeltakerHendelse(
+                sakId = sak.id,
+                fom = deltakelseFom,
+                tom = deltakelsesTom.minusDays(2),
+                deltakerstatus = TiltakDeltakerstatus.Avbrutt,
+                tiltaksdeltakerId = tiltaksdeltakerId,
+            )
+            tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
+                nyligHendelse,
+                "melding",
+                TiltaksdeltakerHendelseKilde.Komet,
+                nå(tac.clock).minusMinutes(10),
+            )
+
+            tac.endretTiltaksdeltakerJobb.håndterEndretTiltaksdeltakerHendelser()
+
+            // Hendelsen skal fortsatt være ubehandlet
+            val ubehandlede = tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede()
+            ubehandlede.any { it.id == nyligHendelse.id } shouldBe true
+
+            val ubehandletHendelse = tac.tiltaksdeltakerHendelsePostgresRepo.hent(nyligHendelse.id)
+            ubehandletHendelse.shouldNotBeNull()
+            ubehandletHendelse.oppgaveId.shouldBeNull()
+            ubehandletHendelse.behandlingId.shouldBeNull()
+
+            // Saken skal ikke ha fått noen ny behandling
+            tac.sakContext.sakRepo.hentForSakId(sak.id)!!.rammebehandlinger shouldHaveSize 1
+        }
+    }
+
+    @Test
     fun `ingen opprettet behandling - ignorerer`() {
         withTestApplicationContextAndPostgres(runIsolated = true) { tac ->
             val fnr = Fnr.random()
@@ -75,7 +127,7 @@ class EndretTiltaksdeltakerJobbTest {
 
             tac.endretTiltaksdeltakerJobb.håndterEndretTiltaksdeltakerHendelser()
 
-            tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede(nå(tac.clock)).none { it.id == tiltaksdeltakerHendelse.id } shouldBe true
+            tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede().none { it.id == tiltaksdeltakerHendelse.id } shouldBe true
         }
     }
 
@@ -109,7 +161,7 @@ class EndretTiltaksdeltakerJobbTest {
 
             tac.endretTiltaksdeltakerJobb.håndterEndretTiltaksdeltakerHendelser()
 
-            tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede(nå(tac.clock)).none { it.id == tiltaksdeltakerHendelse.id } shouldBe true
+            tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede().none { it.id == tiltaksdeltakerHendelse.id } shouldBe true
         }
     }
 
@@ -206,7 +258,7 @@ class EndretTiltaksdeltakerJobbTest {
 
             tac.endretTiltaksdeltakerJobb.håndterEndretTiltaksdeltakerHendelser()
 
-            tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede(nå(tac.clock)).none { it.id == tiltaksdeltakerHendelse.id } shouldBe true
+            tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede().none { it.id == tiltaksdeltakerHendelse.id } shouldBe true
             tac.behandlingContext.rammebehandlingRepo.hent(behandling.id).venterTil?.toLocalDate() shouldBe 1.mai(2025)
         }
     }
@@ -249,7 +301,7 @@ class EndretTiltaksdeltakerJobbTest {
 
             tac.endretTiltaksdeltakerJobb.håndterEndretTiltaksdeltakerHendelser()
 
-            tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede(nå(tac.clock)).none { it.id == tiltaksdeltakerHendelse.id } shouldBe true
+            tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede().none { it.id == tiltaksdeltakerHendelse.id } shouldBe true
         }
     }
 
@@ -314,7 +366,7 @@ class EndretTiltaksdeltakerJobbTest {
 
             tac.endretTiltaksdeltakerJobb.håndterEndretTiltaksdeltakerHendelser()
 
-            tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede(nå(tac.clock)).none { it.id == tiltaksdeltakerHendelse.id } shouldBe true
+            tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede().none { it.id == tiltaksdeltakerHendelse.id } shouldBe true
         }
     }
 
@@ -471,7 +523,7 @@ class EndretTiltaksdeltakerJobbTest {
 
                 tac.endretTiltaksdeltakerJobb.håndterEndretTiltaksdeltakerHendelser()
 
-                tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede(nå(tac.clock)).none { it.id == tiltaksdeltakerHendelse.id } shouldBe true
+                tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede().none { it.id == tiltaksdeltakerHendelse.id } shouldBe true
             }
         }
 
@@ -566,7 +618,7 @@ class EndretTiltaksdeltakerJobbTest {
                 val andreOppdatertTiltaksdeltakerHendelse =
                     tac.tiltaksdeltakerHendelsePostgresRepo.hent(andreTiltaksdeltakerHendelse.id)
                 andreOppdatertTiltaksdeltakerHendelse shouldNotBe null
-                tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede(nå(tac.clock)).none { it.id == andreTiltaksdeltakerHendelse.id } shouldBe true
+                tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede().none { it.id == andreTiltaksdeltakerHendelse.id } shouldBe true
             }
         }
 
@@ -648,7 +700,7 @@ class EndretTiltaksdeltakerJobbTest {
                 val førsteOppdatertTiltaksdeltakerHendelse =
                     tac.tiltaksdeltakerHendelsePostgresRepo.hent(førsteTiltaksdeltakerHendelse.id)
                 førsteOppdatertTiltaksdeltakerHendelse shouldNotBe null
-                tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede(nå(tac.clock)).none { it.id == førsteTiltaksdeltakerHendelse.id } shouldBe true
+                tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede().none { it.id == førsteTiltaksdeltakerHendelse.id } shouldBe true
 
                 val andreOppdatertTiltaksdeltakerHendelse =
                     tac.tiltaksdeltakerHendelsePostgresRepo.hent(andreTiltaksdeltakerHendelse.id)
@@ -726,13 +778,13 @@ class EndretTiltaksdeltakerJobbTest {
                 oppdatertEldreHendelse.shouldNotBeNull()
                 oppdatertEldreHendelse.oppgaveId.shouldBeNull()
                 oppdatertEldreHendelse.behandlingId.shouldBeNull()
-                tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede(nå(tac.clock)).none { it.id == eldreHendelse.id } shouldBe true
+                tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede().none { it.id == eldreHendelse.id } shouldBe true
 
                 // Nyeste hendelse skal ha blitt evaluert og opprettet revurdering
                 val oppdatertNyesteHendelse = tac.tiltaksdeltakerHendelsePostgresRepo.hent(nyesteHendelse.id)
                 oppdatertNyesteHendelse.shouldNotBeNull()
                 oppdatertNyesteHendelse.behandlingId.shouldNotBeNull()
-                tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede(nå(tac.clock)).none { it.id == nyesteHendelse.id } shouldBe true
+                tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede().none { it.id == nyesteHendelse.id } shouldBe true
 
                 val sisteBehandling = tac.sakContext.sakRepo.hentForSakId(sak.id)!!.rammebehandlinger.last()
                 val revurdering = sisteBehandling.shouldBeInstanceOf<Revurdering>()
@@ -804,7 +856,7 @@ class EndretTiltaksdeltakerJobbTest {
 
                 tac.endretTiltaksdeltakerJobb.håndterEndretTiltaksdeltakerHendelser()
 
-                val ubehandlede = tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede(nå(tac.clock))
+                val ubehandlede = tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede()
 
                 // Alle tre skal være markert som behandlet
                 ubehandlede.none { it.id == eldsteHendelse.id } shouldBe true
@@ -915,7 +967,7 @@ class EndretTiltaksdeltakerJobbTest {
 
                 tac.endretTiltaksdeltakerJobb.håndterEndretTiltaksdeltakerHendelser()
 
-                val ubehandlede = tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede(nå(tac.clock))
+                val ubehandlede = tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede()
                 ubehandlede.none { it.id == førsteEldreHendelse.id } shouldBe true
                 ubehandlede.none { it.id == førsteNyesteHendelse.id } shouldBe true
                 ubehandlede.none { it.id == andreHendelse.id } shouldBe true

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/jobb/EndretTiltaksdeltakerJobbTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/jobb/EndretTiltaksdeltakerJobbTest.kt
@@ -65,7 +65,7 @@ class EndretTiltaksdeltakerJobbTest {
                 tiltaksdeltakerId = tiltaksdeltakerId,
             )
 
-            tac.tiltaksdeltakerKafkaRepository.lagre(
+            tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
                 tiltaksdeltakerKafkaDb,
                 "melding",
                 nå(tac.clock).minusMinutes(20),
@@ -73,7 +73,7 @@ class EndretTiltaksdeltakerJobbTest {
 
             tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
 
-            tac.tiltaksdeltakerKafkaRepository.hent(tiltaksdeltakerKafkaDb.id) shouldBe null
+            tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerKafkaDb.id) shouldBe null
         }
     }
 
@@ -98,7 +98,7 @@ class EndretTiltaksdeltakerJobbTest {
                 sakId = sak.id,
             )
 
-            tac.tiltaksdeltakerKafkaRepository.lagre(
+            tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
                 tiltaksdeltakerKafkaDb,
                 "melding",
                 nå(tac.clock).minusMinutes(20),
@@ -106,7 +106,7 @@ class EndretTiltaksdeltakerJobbTest {
 
             tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
 
-            tac.tiltaksdeltakerKafkaRepository.hent(tiltaksdeltakerKafkaDb.id) shouldBe null
+            tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerKafkaDb.id) shouldBe null
         }
     }
 
@@ -138,7 +138,7 @@ class EndretTiltaksdeltakerJobbTest {
                 tom = null,
                 tiltaksdeltakerId = tiltaksdeltakerId,
             )
-            tac.tiltaksdeltakerKafkaRepository.lagre(
+            tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
                 tiltaksdeltakerKafkaDb,
                 "melding",
                 nå(tac.clock).minusMinutes(20),
@@ -146,7 +146,7 @@ class EndretTiltaksdeltakerJobbTest {
 
             tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
 
-            val oppdatertTiltaksdeltakerKafkaDb = tac.tiltaksdeltakerKafkaRepository.hent(tiltaksdeltakerKafkaDb.id)
+            val oppdatertTiltaksdeltakerKafkaDb = tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerKafkaDb.id)
             oppdatertTiltaksdeltakerKafkaDb.shouldNotBeNull()
             oppdatertTiltaksdeltakerKafkaDb.oppgaveId shouldBe oppgaveId
             oppdatertTiltaksdeltakerKafkaDb.behandlingId.shouldBeNull()
@@ -193,7 +193,7 @@ class EndretTiltaksdeltakerJobbTest {
                 tom = null,
                 tiltaksdeltakerId = tiltaksdeltakerId,
             )
-            tac.tiltaksdeltakerKafkaRepository.lagre(
+            tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
                 tiltaksdeltakerKafkaDb,
                 "melding",
                 nå(tac.clock).minusMinutes(20),
@@ -201,7 +201,7 @@ class EndretTiltaksdeltakerJobbTest {
 
             tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
 
-            tac.tiltaksdeltakerKafkaRepository.hent(tiltaksdeltakerKafkaDb.id) shouldBe null
+            tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerKafkaDb.id) shouldBe null
             tac.behandlingContext.rammebehandlingRepo.hent(behandling.id).venterTil?.toLocalDate() shouldBe 1.mai(2025)
         }
     }
@@ -235,7 +235,7 @@ class EndretTiltaksdeltakerJobbTest {
                 deltakelsesprosent = 100F,
                 tiltaksdeltakerId = tiltaksdeltakerId,
             )
-            tac.tiltaksdeltakerKafkaRepository.lagre(
+            tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
                 tiltaksdeltakerKafkaDb,
                 "melding",
                 nå(tac.clock).minusMinutes(20),
@@ -243,7 +243,7 @@ class EndretTiltaksdeltakerJobbTest {
 
             tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
 
-            tac.tiltaksdeltakerKafkaRepository.hent(tiltaksdeltakerKafkaDb.id) shouldBe null
+            tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerKafkaDb.id) shouldBe null
         }
     }
 
@@ -299,7 +299,7 @@ class EndretTiltaksdeltakerJobbTest {
                 deltakelsesprosent = 100F,
                 tiltaksdeltakerId = tiltaksdeltakerId,
             )
-            tac.tiltaksdeltakerKafkaRepository.lagre(
+            tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
                 tiltaksdeltakerKafkaDb,
                 "melding",
                 nå(tac.clock).minusMinutes(20),
@@ -308,7 +308,7 @@ class EndretTiltaksdeltakerJobbTest {
             tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
 
             // Skal slettes fordi det ikke er noen endring
-            tac.tiltaksdeltakerKafkaRepository.hent(tiltaksdeltakerKafkaDb.id) shouldBe null
+            tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerKafkaDb.id) shouldBe null
         }
     }
 
@@ -340,7 +340,7 @@ class EndretTiltaksdeltakerJobbTest {
                 tiltaksdeltakerId = tiltaksdeltakerId,
             )
 
-            tac.tiltaksdeltakerKafkaRepository.lagre(
+            tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
                 tiltaksdeltakerKafkaDb,
                 "melding",
                 nå(tac.clock).minusMinutes(20),
@@ -348,7 +348,7 @@ class EndretTiltaksdeltakerJobbTest {
 
             tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
 
-            val oppdatertTiltaksdeltakerKafkaDb = tac.tiltaksdeltakerKafkaRepository.hent(tiltaksdeltakerKafkaDb.id)
+            val oppdatertTiltaksdeltakerKafkaDb = tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerKafkaDb.id)
 
             val sisteBehandling = tac.sakContext.sakRepo.hentForSakId(sak.id)!!.rammebehandlinger.last()
 
@@ -359,7 +359,7 @@ class EndretTiltaksdeltakerJobbTest {
             val revurdering = sisteBehandling.shouldBeInstanceOf<Revurdering>()
             revurdering.id shouldBe oppdatertTiltaksdeltakerKafkaDb.behandlingId
             val grunn = revurdering.automatiskOpprettetGrunn.shouldNotBeNull()
-            grunn.hendelseId shouldBe tiltaksdeltakerKafkaDb.id
+            grunn.hendelseId shouldBe tiltaksdeltakerKafkaDb.id.toString()
             grunn.endringer shouldHaveSize 2
             grunn.endringer.any { it is TiltaksdeltakerEndring.Forlengelse } shouldBe true
             grunn.endringer.any { it is TiltaksdeltakerEndring.EndretDeltakelsesmengde } shouldBe true
@@ -394,7 +394,7 @@ class EndretTiltaksdeltakerJobbTest {
                 deltakerstatus = TiltakDeltakerstatus.Avbrutt,
                 tiltaksdeltakerId = tiltaksdeltakerId,
             )
-            tac.tiltaksdeltakerKafkaRepository.lagre(
+            tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
                 tiltaksdeltakerKafkaDb,
                 "melding",
                 nå(tac.clock).minusMinutes(20),
@@ -402,7 +402,7 @@ class EndretTiltaksdeltakerJobbTest {
 
             tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
 
-            val oppdatertTiltaksdeltakerKafkaDb = tac.tiltaksdeltakerKafkaRepository.hent(tiltaksdeltakerKafkaDb.id)
+            val oppdatertTiltaksdeltakerKafkaDb = tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerKafkaDb.id)
             oppdatertTiltaksdeltakerKafkaDb shouldNotBe null
             oppdatertTiltaksdeltakerKafkaDb?.oppgaveId shouldBe null
 
@@ -410,7 +410,7 @@ class EndretTiltaksdeltakerJobbTest {
             val revurdering = sisteBehandling.shouldBeInstanceOf<Revurdering>()
             revurdering.id shouldBe oppdatertTiltaksdeltakerKafkaDb?.behandlingId
             val grunn = revurdering.automatiskOpprettetGrunn.shouldNotBeNull()
-            grunn.hendelseId shouldBe tiltaksdeltakerKafkaDb.id
+            grunn.hendelseId shouldBe tiltaksdeltakerKafkaDb.id.toString()
             grunn.endringer shouldHaveSize 1
             grunn.endringer.first().shouldBeInstanceOf<TiltaksdeltakerEndring.AvbruttDeltakelse>()
         }
@@ -454,7 +454,7 @@ class EndretTiltaksdeltakerJobbTest {
                     tiltaksdeltakerId = førsteTiltaksdeltakerId,
                 )
 
-                tac.tiltaksdeltakerKafkaRepository.lagre(
+                tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
                     tiltaksdeltakerKafkaDb,
                     "melding",
                     nå(tac.clock).minusMinutes(20),
@@ -462,7 +462,7 @@ class EndretTiltaksdeltakerJobbTest {
 
                 tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
 
-                tac.tiltaksdeltakerKafkaRepository.hent(tiltaksdeltakerKafkaDb.id) shouldBe null
+                tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerKafkaDb.id) shouldBe null
             }
         }
 
@@ -526,12 +526,12 @@ class EndretTiltaksdeltakerJobbTest {
                     tiltaksdeltakerId = andreTiltaksdeltakerId,
                 )
 
-                tac.tiltaksdeltakerKafkaRepository.lagre(
+                tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
                     førsteTiltaksdeltakerKafkaDb,
                     "melding",
                     nå(tac.clock).minusMinutes(20),
                 )
-                tac.tiltaksdeltakerKafkaRepository.lagre(
+                tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
                     andreTiltaksdeltakerKafkaDb,
                     "melding",
                     nå(tac.clock).minusMinutes(20),
@@ -540,7 +540,7 @@ class EndretTiltaksdeltakerJobbTest {
                 tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
 
                 val førsteOppdatertTiltaksdeltakerKafkaDb =
-                    tac.tiltaksdeltakerKafkaRepository.hent(førsteTiltaksdeltakerKafkaDb.id)
+                    tac.tiltaksdeltakerHendelsePostgresRepo.hent(førsteTiltaksdeltakerKafkaDb.id)
                 førsteOppdatertTiltaksdeltakerKafkaDb shouldNotBe null
                 førsteOppdatertTiltaksdeltakerKafkaDb?.oppgaveId shouldBe null
 
@@ -548,12 +548,12 @@ class EndretTiltaksdeltakerJobbTest {
                 val revurdering = sisteBehandling.shouldBeInstanceOf<Revurdering>()
                 revurdering.id shouldBe førsteOppdatertTiltaksdeltakerKafkaDb?.behandlingId
                 val grunn = revurdering.automatiskOpprettetGrunn.shouldNotBeNull()
-                grunn.hendelseId shouldBe førsteEksternId
+                grunn.hendelseId shouldBe førsteTiltaksdeltakerKafkaDb.id.toString()
                 grunn.endringer shouldHaveSize 1
                 grunn.endringer.first().shouldBeInstanceOf<TiltaksdeltakerEndring.AvbruttDeltakelse>()
 
                 val andreOppdatertTiltaksdeltakerKafkaDb =
-                    tac.tiltaksdeltakerKafkaRepository.hent(andreTiltaksdeltakerKafkaDb.id)
+                    tac.tiltaksdeltakerHendelsePostgresRepo.hent(andreTiltaksdeltakerKafkaDb.id)
                 andreOppdatertTiltaksdeltakerKafkaDb shouldBe null
             }
         }
@@ -618,12 +618,12 @@ class EndretTiltaksdeltakerJobbTest {
                     tiltaksdeltakerId = andreTiltaksdeltakerId,
                 )
 
-                tac.tiltaksdeltakerKafkaRepository.lagre(
+                tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
                     førsteTiltaksdeltakerKafkaDb,
                     "melding",
                     nå(tac.clock).minusMinutes(20),
                 )
-                tac.tiltaksdeltakerKafkaRepository.lagre(
+                tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
                     andreTiltaksdeltakerKafkaDb,
                     "melding",
                     nå(tac.clock).minusMinutes(20),
@@ -632,11 +632,11 @@ class EndretTiltaksdeltakerJobbTest {
                 tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
 
                 val førsteOppdatertTiltaksdeltakerKafkaDb =
-                    tac.tiltaksdeltakerKafkaRepository.hent(førsteTiltaksdeltakerKafkaDb.id)
+                    tac.tiltaksdeltakerHendelsePostgresRepo.hent(førsteTiltaksdeltakerKafkaDb.id)
                 førsteOppdatertTiltaksdeltakerKafkaDb shouldBe null
 
                 val andreOppdatertTiltaksdeltakerKafkaDb =
-                    tac.tiltaksdeltakerKafkaRepository.hent(andreTiltaksdeltakerKafkaDb.id)
+                    tac.tiltaksdeltakerHendelsePostgresRepo.hent(andreTiltaksdeltakerKafkaDb.id)
                 andreOppdatertTiltaksdeltakerKafkaDb shouldNotBe null
                 andreOppdatertTiltaksdeltakerKafkaDb?.oppgaveId shouldBe null
 
@@ -644,7 +644,7 @@ class EndretTiltaksdeltakerJobbTest {
                 val revurdering = sisteBehandling.shouldBeInstanceOf<Revurdering>()
                 revurdering.id shouldBe andreOppdatertTiltaksdeltakerKafkaDb?.behandlingId
                 val grunn = revurdering.automatiskOpprettetGrunn.shouldNotBeNull()
-                grunn.hendelseId shouldBe andreEksternId
+                grunn.hendelseId shouldBe andreTiltaksdeltakerKafkaDb.id.toString()
                 grunn.endringer shouldHaveSize 1
                 grunn.endringer.first().shouldBeInstanceOf<TiltaksdeltakerEndring.AvbruttDeltakelse>()
             }

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/jobb/EndretTiltaksdeltakerJobbTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/jobb/EndretTiltaksdeltakerJobbTest.kt
@@ -32,6 +32,7 @@ import no.nav.tiltakspenger.saksbehandling.routes.RouteBehandlingBuilder.opprett
 import no.nav.tiltakspenger.saksbehandling.routes.RouteBehandlingBuilder.opprettSøknadsbehandlingUnderBehandlingMedInnvilgelse
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.TiltakDeltakerstatus
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.TiltaksdeltakerId
+import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelseKilde
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.repository.getTiltaksdeltakerHendelse
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -68,6 +69,7 @@ class EndretTiltaksdeltakerJobbTest {
             tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
                 tiltaksdeltakerHendelse,
                 "melding",
+                TiltaksdeltakerHendelseKilde.Komet,
                 nå(tac.clock).minusMinutes(20),
             )
 
@@ -101,6 +103,7 @@ class EndretTiltaksdeltakerJobbTest {
             tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
                 tiltaksdeltakerHendelse,
                 "melding",
+                TiltaksdeltakerHendelseKilde.Komet,
                 nå(tac.clock).minusMinutes(20),
             )
 
@@ -141,6 +144,7 @@ class EndretTiltaksdeltakerJobbTest {
             tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
                 tiltaksdeltakerHendelse,
                 "melding",
+                TiltaksdeltakerHendelseKilde.Komet,
                 nå(tac.clock).minusMinutes(20),
             )
 
@@ -196,6 +200,7 @@ class EndretTiltaksdeltakerJobbTest {
             tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
                 tiltaksdeltakerHendelse,
                 "melding",
+                TiltaksdeltakerHendelseKilde.Komet,
                 nå(tac.clock).minusMinutes(20),
             )
 
@@ -238,6 +243,7 @@ class EndretTiltaksdeltakerJobbTest {
             tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
                 tiltaksdeltakerHendelse,
                 "melding",
+                TiltaksdeltakerHendelseKilde.Komet,
                 nå(tac.clock).minusMinutes(20),
             )
 
@@ -302,6 +308,7 @@ class EndretTiltaksdeltakerJobbTest {
             tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
                 tiltaksdeltakerHendelse,
                 "melding",
+                TiltaksdeltakerHendelseKilde.Komet,
                 nå(tac.clock).minusMinutes(20),
             )
 
@@ -343,6 +350,7 @@ class EndretTiltaksdeltakerJobbTest {
             tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
                 tiltaksdeltakerHendelse,
                 "melding",
+                TiltaksdeltakerHendelseKilde.Komet,
                 nå(tac.clock).minusMinutes(20),
             )
 
@@ -397,6 +405,7 @@ class EndretTiltaksdeltakerJobbTest {
             tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
                 tiltaksdeltakerHendelse,
                 "melding",
+                TiltaksdeltakerHendelseKilde.Komet,
                 nå(tac.clock).minusMinutes(20),
             )
 
@@ -457,6 +466,7 @@ class EndretTiltaksdeltakerJobbTest {
                 tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
                     tiltaksdeltakerHendelse,
                     "melding",
+                    TiltaksdeltakerHendelseKilde.Komet,
                     nå(tac.clock).minusMinutes(20),
                 )
 
@@ -529,11 +539,13 @@ class EndretTiltaksdeltakerJobbTest {
                 tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
                     førsteTiltaksdeltakerHendelse,
                     "melding",
+                    TiltaksdeltakerHendelseKilde.Komet,
                     nå(tac.clock).minusMinutes(20),
                 )
                 tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
                     andreTiltaksdeltakerHendelse,
                     "melding",
+                    TiltaksdeltakerHendelseKilde.Komet,
                     nå(tac.clock).minusMinutes(20),
                 )
 
@@ -621,11 +633,13 @@ class EndretTiltaksdeltakerJobbTest {
                 tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
                     førsteTiltaksdeltakerHendelse,
                     "melding",
+                    TiltaksdeltakerHendelseKilde.Komet,
                     nå(tac.clock).minusMinutes(20),
                 )
                 tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
                     andreTiltaksdeltakerHendelse,
                     "melding",
+                    TiltaksdeltakerHendelseKilde.Komet,
                     nå(tac.clock).minusMinutes(20),
                 )
 

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/jobb/EndretTiltaksdeltakerJobbTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/jobb/EndretTiltaksdeltakerJobbTest.kt
@@ -32,7 +32,7 @@ import no.nav.tiltakspenger.saksbehandling.routes.RouteBehandlingBuilder.opprett
 import no.nav.tiltakspenger.saksbehandling.routes.RouteBehandlingBuilder.opprettSøknadsbehandlingUnderBehandlingMedInnvilgelse
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.TiltakDeltakerstatus
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.TiltaksdeltakerId
-import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.repository.getTiltaksdeltakerKafkaDb
+import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.repository.getTiltaksdeltakerHendelse
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
@@ -60,20 +60,20 @@ class EndretTiltaksdeltakerJobbTest {
                 tiltaksdeltakelse = tiltaksdeltakelse,
             )
 
-            val tiltaksdeltakerKafkaDb = getTiltaksdeltakerKafkaDb(
+            val tiltaksdeltakerHendelse = getTiltaksdeltakerHendelse(
                 sakId = sak.id,
                 tiltaksdeltakerId = tiltaksdeltakerId,
             )
 
             tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
-                tiltaksdeltakerKafkaDb,
+                tiltaksdeltakerHendelse,
                 "melding",
                 nå(tac.clock).minusMinutes(20),
             )
 
             tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
 
-            tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerKafkaDb.id) shouldBe null
+            tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerHendelse.id) shouldBe null
         }
     }
 
@@ -94,19 +94,19 @@ class EndretTiltaksdeltakerJobbTest {
             )
 
             // Opprett tiltaksdeltaker for en annen deltakerId enn den i behandlingen
-            val tiltaksdeltakerKafkaDb = getTiltaksdeltakerKafkaDb(
+            val tiltaksdeltakerHendelse = getTiltaksdeltakerHendelse(
                 sakId = sak.id,
             )
 
             tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
-                tiltaksdeltakerKafkaDb,
+                tiltaksdeltakerHendelse,
                 "melding",
                 nå(tac.clock).minusMinutes(20),
             )
 
             tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
 
-            tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerKafkaDb.id) shouldBe null
+            tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerHendelse.id) shouldBe null
         }
     }
 
@@ -131,7 +131,7 @@ class EndretTiltaksdeltakerJobbTest {
                 innvilgelsesperioder = innvilgelsesperioder(deltakelsesperiode, tiltaksdeltakelse),
             )
 
-            val tiltaksdeltakerKafkaDb = getTiltaksdeltakerKafkaDb(
+            val tiltaksdeltakerHendelse = getTiltaksdeltakerHendelse(
                 sakId = sak.id,
                 deltakerstatus = TiltakDeltakerstatus.IkkeAktuell,
                 fom = null,
@@ -139,17 +139,17 @@ class EndretTiltaksdeltakerJobbTest {
                 tiltaksdeltakerId = tiltaksdeltakerId,
             )
             tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
-                tiltaksdeltakerKafkaDb,
+                tiltaksdeltakerHendelse,
                 "melding",
                 nå(tac.clock).minusMinutes(20),
             )
 
             tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
 
-            val oppdatertTiltaksdeltakerKafkaDb = tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerKafkaDb.id)
-            oppdatertTiltaksdeltakerKafkaDb.shouldNotBeNull()
-            oppdatertTiltaksdeltakerKafkaDb.oppgaveId shouldBe oppgaveId
-            oppdatertTiltaksdeltakerKafkaDb.behandlingId.shouldBeNull()
+            val oppdatertTiltaksdeltakerHendelse = tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerHendelse.id)
+            oppdatertTiltaksdeltakerHendelse.shouldNotBeNull()
+            oppdatertTiltaksdeltakerHendelse.oppgaveId shouldBe oppgaveId
+            oppdatertTiltaksdeltakerHendelse.behandlingId.shouldBeNull()
         }
     }
 
@@ -186,7 +186,7 @@ class EndretTiltaksdeltakerJobbTest {
             val behandlingPaVent = behandling.settPåVent(kommando = kommando, clock = tac.clock).first as Søknadsbehandling
             tac.behandlingContext.rammebehandlingRepo.lagre(behandlingPaVent)
 
-            val tiltaksdeltakerKafkaDb = getTiltaksdeltakerKafkaDb(
+            val tiltaksdeltakerHendelse = getTiltaksdeltakerHendelse(
                 sakId = sak.id,
                 deltakerstatus = TiltakDeltakerstatus.IkkeAktuell,
                 fom = null,
@@ -194,14 +194,14 @@ class EndretTiltaksdeltakerJobbTest {
                 tiltaksdeltakerId = tiltaksdeltakerId,
             )
             tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
-                tiltaksdeltakerKafkaDb,
+                tiltaksdeltakerHendelse,
                 "melding",
                 nå(tac.clock).minusMinutes(20),
             )
 
             tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
 
-            tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerKafkaDb.id) shouldBe null
+            tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerHendelse.id) shouldBe null
             tac.behandlingContext.rammebehandlingRepo.hent(behandling.id).venterTil?.toLocalDate() shouldBe 1.mai(2025)
         }
     }
@@ -227,7 +227,7 @@ class EndretTiltaksdeltakerJobbTest {
                 tiltaksdeltakelse = tiltaksdeltakelse,
             )
 
-            val tiltaksdeltakerKafkaDb = getTiltaksdeltakerKafkaDb(
+            val tiltaksdeltakerHendelse = getTiltaksdeltakerHendelse(
                 sakId = sak.id,
                 fom = deltakelseFom,
                 tom = deltakelsesTom,
@@ -236,14 +236,14 @@ class EndretTiltaksdeltakerJobbTest {
                 tiltaksdeltakerId = tiltaksdeltakerId,
             )
             tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
-                tiltaksdeltakerKafkaDb,
+                tiltaksdeltakerHendelse,
                 "melding",
                 nå(tac.clock).minusMinutes(20),
             )
 
             tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
 
-            tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerKafkaDb.id) shouldBe null
+            tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerHendelse.id) shouldBe null
         }
     }
 
@@ -291,7 +291,7 @@ class EndretTiltaksdeltakerJobbTest {
             )
 
             // Opprett tiltaksdeltakerKafka med samme forlengede tom som revurderingen
-            val tiltaksdeltakerKafkaDb = getTiltaksdeltakerKafkaDb(
+            val tiltaksdeltakerHendelse = getTiltaksdeltakerHendelse(
                 sakId = sak.id,
                 fom = deltakelseFom,
                 tom = forlengetDeltakelsesTom,
@@ -300,7 +300,7 @@ class EndretTiltaksdeltakerJobbTest {
                 tiltaksdeltakerId = tiltaksdeltakerId,
             )
             tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
-                tiltaksdeltakerKafkaDb,
+                tiltaksdeltakerHendelse,
                 "melding",
                 nå(tac.clock).minusMinutes(20),
             )
@@ -308,7 +308,7 @@ class EndretTiltaksdeltakerJobbTest {
             tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
 
             // Skal slettes fordi det ikke er noen endring
-            tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerKafkaDb.id) shouldBe null
+            tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerHendelse.id) shouldBe null
         }
     }
 
@@ -333,7 +333,7 @@ class EndretTiltaksdeltakerJobbTest {
                 tiltaksdeltakelse = tiltaksdeltakelse,
             )
 
-            val tiltaksdeltakerKafkaDb = getTiltaksdeltakerKafkaDb(
+            val tiltaksdeltakerHendelse = getTiltaksdeltakerHendelse(
                 sakId = sak.id,
                 fom = deltakelseFom,
                 tom = deltakelsesTom.plusMonths(1),
@@ -341,25 +341,25 @@ class EndretTiltaksdeltakerJobbTest {
             )
 
             tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
-                tiltaksdeltakerKafkaDb,
+                tiltaksdeltakerHendelse,
                 "melding",
                 nå(tac.clock).minusMinutes(20),
             )
 
             tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
 
-            val oppdatertTiltaksdeltakerKafkaDb = tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerKafkaDb.id)
+            val oppdatertTiltaksdeltakerHendelse = tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerHendelse.id)
 
             val sisteBehandling = tac.sakContext.sakRepo.hentForSakId(sak.id)!!.rammebehandlinger.last()
 
-            oppdatertTiltaksdeltakerKafkaDb.shouldNotBeNull()
-            oppdatertTiltaksdeltakerKafkaDb.oppgaveId.shouldBeNull()
-            oppdatertTiltaksdeltakerKafkaDb.behandlingId shouldBe sisteBehandling.id
+            oppdatertTiltaksdeltakerHendelse.shouldNotBeNull()
+            oppdatertTiltaksdeltakerHendelse.oppgaveId.shouldBeNull()
+            oppdatertTiltaksdeltakerHendelse.behandlingId shouldBe sisteBehandling.id
 
             val revurdering = sisteBehandling.shouldBeInstanceOf<Revurdering>()
-            revurdering.id shouldBe oppdatertTiltaksdeltakerKafkaDb.behandlingId
+            revurdering.id shouldBe oppdatertTiltaksdeltakerHendelse.behandlingId
             val grunn = revurdering.automatiskOpprettetGrunn.shouldNotBeNull()
-            grunn.hendelseId shouldBe tiltaksdeltakerKafkaDb.id.toString()
+            grunn.hendelseId shouldBe tiltaksdeltakerHendelse.id.toString()
             grunn.endringer shouldHaveSize 2
             grunn.endringer.any { it is TiltaksdeltakerEndring.Forlengelse } shouldBe true
             grunn.endringer.any { it is TiltaksdeltakerEndring.EndretDeltakelsesmengde } shouldBe true
@@ -387,7 +387,7 @@ class EndretTiltaksdeltakerJobbTest {
                 tiltaksdeltakelse = tiltaksdeltakelse,
             )
 
-            val tiltaksdeltakerKafkaDb = getTiltaksdeltakerKafkaDb(
+            val tiltaksdeltakerHendelse = getTiltaksdeltakerHendelse(
                 sakId = sak.id,
                 fom = deltakelseFom,
                 tom = deltakelsesTom.minusDays(2),
@@ -395,22 +395,22 @@ class EndretTiltaksdeltakerJobbTest {
                 tiltaksdeltakerId = tiltaksdeltakerId,
             )
             tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
-                tiltaksdeltakerKafkaDb,
+                tiltaksdeltakerHendelse,
                 "melding",
                 nå(tac.clock).minusMinutes(20),
             )
 
             tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
 
-            val oppdatertTiltaksdeltakerKafkaDb = tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerKafkaDb.id)
-            oppdatertTiltaksdeltakerKafkaDb shouldNotBe null
-            oppdatertTiltaksdeltakerKafkaDb?.oppgaveId shouldBe null
+            val oppdatertTiltaksdeltakerHendelse = tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerHendelse.id)
+            oppdatertTiltaksdeltakerHendelse shouldNotBe null
+            oppdatertTiltaksdeltakerHendelse?.oppgaveId shouldBe null
 
             val sisteBehandling = tac.sakContext.sakRepo.hentForSakId(sak.id)!!.rammebehandlinger.last()
             val revurdering = sisteBehandling.shouldBeInstanceOf<Revurdering>()
-            revurdering.id shouldBe oppdatertTiltaksdeltakerKafkaDb?.behandlingId
+            revurdering.id shouldBe oppdatertTiltaksdeltakerHendelse?.behandlingId
             val grunn = revurdering.automatiskOpprettetGrunn.shouldNotBeNull()
-            grunn.hendelseId shouldBe tiltaksdeltakerKafkaDb.id.toString()
+            grunn.hendelseId shouldBe tiltaksdeltakerHendelse.id.toString()
             grunn.endringer shouldHaveSize 1
             grunn.endringer.first().shouldBeInstanceOf<TiltaksdeltakerEndring.AvbruttDeltakelse>()
         }
@@ -446,7 +446,7 @@ class EndretTiltaksdeltakerJobbTest {
                     stansFraOgMed = rammevedtak.fraOgMed,
                 )
 
-                val tiltaksdeltakerKafkaDb = getTiltaksdeltakerKafkaDb(
+                val tiltaksdeltakerHendelse = getTiltaksdeltakerHendelse(
                     sakId = sak.id,
                     fom = førsteDeltakelseFom,
                     tom = LocalDate.now(tac.clock),
@@ -455,14 +455,14 @@ class EndretTiltaksdeltakerJobbTest {
                 )
 
                 tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
-                    tiltaksdeltakerKafkaDb,
+                    tiltaksdeltakerHendelse,
                     "melding",
                     nå(tac.clock).minusMinutes(20),
                 )
 
                 tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
 
-                tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerKafkaDb.id) shouldBe null
+                tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerHendelse.id) shouldBe null
             }
         }
 
@@ -509,7 +509,7 @@ class EndretTiltaksdeltakerJobbTest {
                     tiltaksdeltakelse = andreTiltaksdeltakelse,
                 )
 
-                val førsteTiltaksdeltakerKafkaDb = getTiltaksdeltakerKafkaDb(
+                val førsteTiltaksdeltakerHendelse = getTiltaksdeltakerHendelse(
                     id = førsteEksternId,
                     sakId = sak.id,
                     fom = førsteDeltakelseFom,
@@ -517,7 +517,7 @@ class EndretTiltaksdeltakerJobbTest {
                     deltakerstatus = TiltakDeltakerstatus.Avbrutt,
                     tiltaksdeltakerId = førsteTiltaksdeltakerId,
                 )
-                val andreTiltaksdeltakerKafkaDb = getTiltaksdeltakerKafkaDb(
+                val andreTiltaksdeltakerHendelse = getTiltaksdeltakerHendelse(
                     id = andreEksternId,
                     sakId = sak.id,
                     fom = andreDeltakelseFom,
@@ -527,34 +527,34 @@ class EndretTiltaksdeltakerJobbTest {
                 )
 
                 tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
-                    førsteTiltaksdeltakerKafkaDb,
+                    førsteTiltaksdeltakerHendelse,
                     "melding",
                     nå(tac.clock).minusMinutes(20),
                 )
                 tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
-                    andreTiltaksdeltakerKafkaDb,
+                    andreTiltaksdeltakerHendelse,
                     "melding",
                     nå(tac.clock).minusMinutes(20),
                 )
 
                 tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
 
-                val førsteOppdatertTiltaksdeltakerKafkaDb =
-                    tac.tiltaksdeltakerHendelsePostgresRepo.hent(førsteTiltaksdeltakerKafkaDb.id)
-                førsteOppdatertTiltaksdeltakerKafkaDb shouldNotBe null
-                førsteOppdatertTiltaksdeltakerKafkaDb?.oppgaveId shouldBe null
+                val førsteOppdatertTiltaksdeltakerHendelse =
+                    tac.tiltaksdeltakerHendelsePostgresRepo.hent(førsteTiltaksdeltakerHendelse.id)
+                førsteOppdatertTiltaksdeltakerHendelse shouldNotBe null
+                førsteOppdatertTiltaksdeltakerHendelse?.oppgaveId shouldBe null
 
                 val sisteBehandling = tac.sakContext.sakRepo.hentForSakId(sak.id)!!.rammebehandlinger.last()
                 val revurdering = sisteBehandling.shouldBeInstanceOf<Revurdering>()
-                revurdering.id shouldBe førsteOppdatertTiltaksdeltakerKafkaDb?.behandlingId
+                revurdering.id shouldBe førsteOppdatertTiltaksdeltakerHendelse?.behandlingId
                 val grunn = revurdering.automatiskOpprettetGrunn.shouldNotBeNull()
-                grunn.hendelseId shouldBe førsteTiltaksdeltakerKafkaDb.id.toString()
+                grunn.hendelseId shouldBe førsteTiltaksdeltakerHendelse.id.toString()
                 grunn.endringer shouldHaveSize 1
                 grunn.endringer.first().shouldBeInstanceOf<TiltaksdeltakerEndring.AvbruttDeltakelse>()
 
-                val andreOppdatertTiltaksdeltakerKafkaDb =
-                    tac.tiltaksdeltakerHendelsePostgresRepo.hent(andreTiltaksdeltakerKafkaDb.id)
-                andreOppdatertTiltaksdeltakerKafkaDb shouldBe null
+                val andreOppdatertTiltaksdeltakerHendelse =
+                    tac.tiltaksdeltakerHendelsePostgresRepo.hent(andreTiltaksdeltakerHendelse.id)
+                andreOppdatertTiltaksdeltakerHendelse shouldBe null
             }
         }
 
@@ -601,7 +601,7 @@ class EndretTiltaksdeltakerJobbTest {
                     tiltaksdeltakelse = andreTiltaksdeltakelse,
                 )
 
-                val førsteTiltaksdeltakerKafkaDb = getTiltaksdeltakerKafkaDb(
+                val førsteTiltaksdeltakerHendelse = getTiltaksdeltakerHendelse(
                     id = førsteEksternId,
                     sakId = sak.id,
                     fom = førsteDeltakelseFom,
@@ -609,7 +609,7 @@ class EndretTiltaksdeltakerJobbTest {
                     deltakerstatus = TiltakDeltakerstatus.Avbrutt,
                     tiltaksdeltakerId = førsteTiltaksdeltakerId,
                 )
-                val andreTiltaksdeltakerKafkaDb = getTiltaksdeltakerKafkaDb(
+                val andreTiltaksdeltakerHendelse = getTiltaksdeltakerHendelse(
                     id = andreEksternId,
                     sakId = sak.id,
                     fom = andreDeltakelseFom,
@@ -619,32 +619,32 @@ class EndretTiltaksdeltakerJobbTest {
                 )
 
                 tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
-                    førsteTiltaksdeltakerKafkaDb,
+                    førsteTiltaksdeltakerHendelse,
                     "melding",
                     nå(tac.clock).minusMinutes(20),
                 )
                 tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
-                    andreTiltaksdeltakerKafkaDb,
+                    andreTiltaksdeltakerHendelse,
                     "melding",
                     nå(tac.clock).minusMinutes(20),
                 )
 
                 tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
 
-                val førsteOppdatertTiltaksdeltakerKafkaDb =
-                    tac.tiltaksdeltakerHendelsePostgresRepo.hent(førsteTiltaksdeltakerKafkaDb.id)
-                førsteOppdatertTiltaksdeltakerKafkaDb shouldBe null
+                val førsteOppdatertTiltaksdeltakerHendelse =
+                    tac.tiltaksdeltakerHendelsePostgresRepo.hent(førsteTiltaksdeltakerHendelse.id)
+                førsteOppdatertTiltaksdeltakerHendelse shouldBe null
 
-                val andreOppdatertTiltaksdeltakerKafkaDb =
-                    tac.tiltaksdeltakerHendelsePostgresRepo.hent(andreTiltaksdeltakerKafkaDb.id)
-                andreOppdatertTiltaksdeltakerKafkaDb shouldNotBe null
-                andreOppdatertTiltaksdeltakerKafkaDb?.oppgaveId shouldBe null
+                val andreOppdatertTiltaksdeltakerHendelse =
+                    tac.tiltaksdeltakerHendelsePostgresRepo.hent(andreTiltaksdeltakerHendelse.id)
+                andreOppdatertTiltaksdeltakerHendelse shouldNotBe null
+                andreOppdatertTiltaksdeltakerHendelse?.oppgaveId shouldBe null
 
                 val sisteBehandling = tac.sakContext.sakRepo.hentForSakId(sak.id)!!.rammebehandlinger.last()
                 val revurdering = sisteBehandling.shouldBeInstanceOf<Revurdering>()
-                revurdering.id shouldBe andreOppdatertTiltaksdeltakerKafkaDb?.behandlingId
+                revurdering.id shouldBe andreOppdatertTiltaksdeltakerHendelse?.behandlingId
                 val grunn = revurdering.automatiskOpprettetGrunn.shouldNotBeNull()
-                grunn.hendelseId shouldBe andreTiltaksdeltakerKafkaDb.id.toString()
+                grunn.hendelseId shouldBe andreTiltaksdeltakerHendelse.id.toString()
                 grunn.endringer shouldHaveSize 1
                 grunn.endringer.first().shouldBeInstanceOf<TiltaksdeltakerEndring.AvbruttDeltakelse>()
             }

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/jobb/EndretTiltaksdeltakerJobbTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/jobb/EndretTiltaksdeltakerJobbTest.kt
@@ -43,7 +43,7 @@ class EndretTiltaksdeltakerJobbTest {
     private val oppgaveId = oppgaveId()
 
     @Test
-    fun `ingen opprettet behandling - sletter fra db`() {
+    fun `ingen opprettet behandling - ignorerer`() {
         withTestApplicationContextAndPostgres(runIsolated = true) { tac ->
             val fnr = Fnr.random()
             val tiltaksdeltakerId = TiltaksdeltakerId.random()
@@ -73,14 +73,14 @@ class EndretTiltaksdeltakerJobbTest {
                 nå(tac.clock).minusMinutes(20),
             )
 
-            tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
+            tac.endretTiltaksdeltakerJobb.håndterEndretTiltaksdeltakerHendelser()
 
-            tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerHendelse.id) shouldBe null
+            tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede(nå(tac.clock)).none { it.id == tiltaksdeltakerHendelse.id } shouldBe true
         }
     }
 
     @Test
-    fun `ingen behandling for endret deltaker - sletter fra db`() {
+    fun `ingen behandling for endret deltaker - ignorerer`() {
         withTestApplicationContextAndPostgres(runIsolated = true) { tac ->
             val fnr = Fnr.random()
             val deltakelsesperiode = 5.januar(2025) til 5.mai(2025)
@@ -107,9 +107,9 @@ class EndretTiltaksdeltakerJobbTest {
                 nå(tac.clock).minusMinutes(20),
             )
 
-            tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
+            tac.endretTiltaksdeltakerJobb.håndterEndretTiltaksdeltakerHendelser()
 
-            tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerHendelse.id) shouldBe null
+            tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede(nå(tac.clock)).none { it.id == tiltaksdeltakerHendelse.id } shouldBe true
         }
     }
 
@@ -148,7 +148,7 @@ class EndretTiltaksdeltakerJobbTest {
                 nå(tac.clock).minusMinutes(20),
             )
 
-            tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
+            tac.endretTiltaksdeltakerJobb.håndterEndretTiltaksdeltakerHendelser()
 
             val oppdatertTiltaksdeltakerHendelse = tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerHendelse.id)
             oppdatertTiltaksdeltakerHendelse.shouldNotBeNull()
@@ -204,15 +204,15 @@ class EndretTiltaksdeltakerJobbTest {
                 nå(tac.clock).minusMinutes(20),
             )
 
-            tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
+            tac.endretTiltaksdeltakerJobb.håndterEndretTiltaksdeltakerHendelser()
 
-            tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerHendelse.id) shouldBe null
+            tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede(nå(tac.clock)).none { it.id == tiltaksdeltakerHendelse.id } shouldBe true
             tac.behandlingContext.rammebehandlingRepo.hent(behandling.id).venterTil?.toLocalDate() shouldBe 1.mai(2025)
         }
     }
 
     @Test
-    fun `iverksatt behandling, ingen endring - sletter fra db`() {
+    fun `iverksatt behandling, ingen endring - ignorerer`() {
         withTestApplicationContextAndPostgres(runIsolated = true) { tac ->
             val fnr = Fnr.random()
             val tiltaksdeltakerId = TiltaksdeltakerId.random()
@@ -247,14 +247,14 @@ class EndretTiltaksdeltakerJobbTest {
                 nå(tac.clock).minusMinutes(20),
             )
 
-            tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
+            tac.endretTiltaksdeltakerJobb.håndterEndretTiltaksdeltakerHendelser()
 
-            tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerHendelse.id) shouldBe null
+            tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede(nå(tac.clock)).none { it.id == tiltaksdeltakerHendelse.id } shouldBe true
         }
     }
 
     @Test
-    fun `iverksatt søknadsbehandling + revurdering innvilgelse - forlenget tom til samme som revurderingen - sletter fra db`() {
+    fun `iverksatt søknadsbehandling + revurdering innvilgelse - forlenget tom til samme som revurderingen - ignorerer`() {
         withTestApplicationContextAndPostgres(runIsolated = true) { tac ->
             val fnr = Fnr.random()
             val tiltaksdeltakerId = TiltaksdeltakerId.random()
@@ -312,10 +312,9 @@ class EndretTiltaksdeltakerJobbTest {
                 nå(tac.clock).minusMinutes(20),
             )
 
-            tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
+            tac.endretTiltaksdeltakerJobb.håndterEndretTiltaksdeltakerHendelser()
 
-            // Skal slettes fordi det ikke er noen endring
-            tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerHendelse.id) shouldBe null
+            tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede(nå(tac.clock)).none { it.id == tiltaksdeltakerHendelse.id } shouldBe true
         }
     }
 
@@ -354,7 +353,7 @@ class EndretTiltaksdeltakerJobbTest {
                 nå(tac.clock).minusMinutes(20),
             )
 
-            tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
+            tac.endretTiltaksdeltakerJobb.håndterEndretTiltaksdeltakerHendelser()
 
             val oppdatertTiltaksdeltakerHendelse = tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerHendelse.id)
 
@@ -409,7 +408,7 @@ class EndretTiltaksdeltakerJobbTest {
                 nå(tac.clock).minusMinutes(20),
             )
 
-            tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
+            tac.endretTiltaksdeltakerJobb.håndterEndretTiltaksdeltakerHendelser()
 
             val oppdatertTiltaksdeltakerHendelse = tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerHendelse.id)
             oppdatertTiltaksdeltakerHendelse shouldNotBe null
@@ -470,9 +469,9 @@ class EndretTiltaksdeltakerJobbTest {
                     nå(tac.clock).minusMinutes(20),
                 )
 
-                tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
+                tac.endretTiltaksdeltakerJobb.håndterEndretTiltaksdeltakerHendelser()
 
-                tac.tiltaksdeltakerHendelsePostgresRepo.hent(tiltaksdeltakerHendelse.id) shouldBe null
+                tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede(nå(tac.clock)).none { it.id == tiltaksdeltakerHendelse.id } shouldBe true
             }
         }
 
@@ -549,7 +548,7 @@ class EndretTiltaksdeltakerJobbTest {
                     nå(tac.clock).minusMinutes(20),
                 )
 
-                tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
+                tac.endretTiltaksdeltakerJobb.håndterEndretTiltaksdeltakerHendelser()
 
                 val førsteOppdatertTiltaksdeltakerHendelse =
                     tac.tiltaksdeltakerHendelsePostgresRepo.hent(førsteTiltaksdeltakerHendelse.id)
@@ -566,7 +565,8 @@ class EndretTiltaksdeltakerJobbTest {
 
                 val andreOppdatertTiltaksdeltakerHendelse =
                     tac.tiltaksdeltakerHendelsePostgresRepo.hent(andreTiltaksdeltakerHendelse.id)
-                andreOppdatertTiltaksdeltakerHendelse shouldBe null
+                andreOppdatertTiltaksdeltakerHendelse shouldNotBe null
+                tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede(nå(tac.clock)).none { it.id == andreTiltaksdeltakerHendelse.id } shouldBe true
             }
         }
 
@@ -643,11 +643,12 @@ class EndretTiltaksdeltakerJobbTest {
                     nå(tac.clock).minusMinutes(20),
                 )
 
-                tac.endretTiltaksdeltakerJobb.opprettOppgaveEllerRevurderingForEndredeDeltakere()
+                tac.endretTiltaksdeltakerJobb.håndterEndretTiltaksdeltakerHendelser()
 
                 val førsteOppdatertTiltaksdeltakerHendelse =
                     tac.tiltaksdeltakerHendelsePostgresRepo.hent(førsteTiltaksdeltakerHendelse.id)
-                førsteOppdatertTiltaksdeltakerHendelse shouldBe null
+                førsteOppdatertTiltaksdeltakerHendelse shouldNotBe null
+                tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede(nå(tac.clock)).none { it.id == førsteTiltaksdeltakerHendelse.id } shouldBe true
 
                 val andreOppdatertTiltaksdeltakerHendelse =
                     tac.tiltaksdeltakerHendelsePostgresRepo.hent(andreTiltaksdeltakerHendelse.id)
@@ -661,6 +662,277 @@ class EndretTiltaksdeltakerJobbTest {
                 grunn.hendelseId shouldBe andreTiltaksdeltakerHendelse.id.toString()
                 grunn.endringer shouldHaveSize 1
                 grunn.endringer.first().shouldBeInstanceOf<TiltaksdeltakerEndring.AvbruttDeltakelse>()
+            }
+        }
+    }
+
+    @Nested
+    inner class `Flere hendelser for samme internDeltakerId` {
+
+        @Test
+        fun `kun nyeste hendelse evalueres, eldre hendelser markeres som behandlet`() {
+            withTestApplicationContextAndPostgres(runIsolated = true) { tac ->
+                val fnr = Fnr.random()
+                val tiltaksdeltakerId = TiltaksdeltakerId.random()
+                val deltakelseFom = 5.januar(2025)
+                val deltakelsesTom = 5.mai(2025)
+                val deltakelsesperiode = deltakelseFom til deltakelsesTom
+
+                val tiltaksdeltakelse = tiltaksdeltakelse(
+                    periode = deltakelsesperiode,
+                    internDeltakelseId = tiltaksdeltakerId,
+                )
+
+                val (sak) = iverksettSøknadsbehandling(
+                    tac = tac,
+                    fnr = fnr,
+                    innvilgelsesperioder = innvilgelsesperioder(deltakelsesperiode, tiltaksdeltakelse),
+                    tiltaksdeltakelse = tiltaksdeltakelse,
+                )
+
+                // Eldre hendelse: forlengelse
+                val eldreHendelse = getTiltaksdeltakerHendelse(
+                    sakId = sak.id,
+                    fom = deltakelseFom,
+                    tom = deltakelsesTom.plusMonths(1),
+                    tiltaksdeltakerId = tiltaksdeltakerId,
+                )
+                tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
+                    eldreHendelse,
+                    "melding1",
+                    TiltaksdeltakerHendelseKilde.Komet,
+                    nå(tac.clock).minusMinutes(30),
+                )
+
+                // Nyeste hendelse: avbrutt
+                val nyesteHendelse = getTiltaksdeltakerHendelse(
+                    sakId = sak.id,
+                    fom = deltakelseFom,
+                    tom = deltakelsesTom.minusDays(2),
+                    deltakerstatus = TiltakDeltakerstatus.Avbrutt,
+                    tiltaksdeltakerId = tiltaksdeltakerId,
+                )
+                tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
+                    nyesteHendelse,
+                    "melding2",
+                    TiltaksdeltakerHendelseKilde.Komet,
+                    nå(tac.clock).minusMinutes(20),
+                )
+
+                tac.endretTiltaksdeltakerJobb.håndterEndretTiltaksdeltakerHendelser()
+
+                // Eldre hendelse skal være markert som behandlet uten oppgave eller revurdering
+                val oppdatertEldreHendelse = tac.tiltaksdeltakerHendelsePostgresRepo.hent(eldreHendelse.id)
+                oppdatertEldreHendelse.shouldNotBeNull()
+                oppdatertEldreHendelse.oppgaveId.shouldBeNull()
+                oppdatertEldreHendelse.behandlingId.shouldBeNull()
+                tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede(nå(tac.clock)).none { it.id == eldreHendelse.id } shouldBe true
+
+                // Nyeste hendelse skal ha blitt evaluert og opprettet revurdering
+                val oppdatertNyesteHendelse = tac.tiltaksdeltakerHendelsePostgresRepo.hent(nyesteHendelse.id)
+                oppdatertNyesteHendelse.shouldNotBeNull()
+                oppdatertNyesteHendelse.behandlingId.shouldNotBeNull()
+                tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede(nå(tac.clock)).none { it.id == nyesteHendelse.id } shouldBe true
+
+                val sisteBehandling = tac.sakContext.sakRepo.hentForSakId(sak.id)!!.rammebehandlinger.last()
+                val revurdering = sisteBehandling.shouldBeInstanceOf<Revurdering>()
+                revurdering.id shouldBe oppdatertNyesteHendelse.behandlingId
+                val grunn = revurdering.automatiskOpprettetGrunn.shouldNotBeNull()
+                grunn.hendelseId shouldBe nyesteHendelse.id.toString()
+            }
+        }
+
+        @Test
+        fun `tre hendelser for samme deltaker - kun siste evalueres, to eldre ignoreres`() {
+            withTestApplicationContextAndPostgres(runIsolated = true) { tac ->
+                val fnr = Fnr.random()
+                val tiltaksdeltakerId = TiltaksdeltakerId.random()
+                val deltakelseFom = 5.januar(2025)
+                val deltakelsesTom = 5.mai(2025)
+                val deltakelsesperiode = deltakelseFom til deltakelsesTom
+
+                val tiltaksdeltakelse = tiltaksdeltakelse(
+                    periode = deltakelsesperiode,
+                    internDeltakelseId = tiltaksdeltakerId,
+                )
+
+                val (sak) = iverksettSøknadsbehandling(
+                    tac = tac,
+                    fnr = fnr,
+                    innvilgelsesperioder = innvilgelsesperioder(deltakelsesperiode, tiltaksdeltakelse),
+                    tiltaksdeltakelse = tiltaksdeltakelse,
+                )
+
+                val eldsteHendelse = getTiltaksdeltakerHendelse(
+                    sakId = sak.id,
+                    fom = deltakelseFom,
+                    tom = deltakelsesTom.plusWeeks(1),
+                    tiltaksdeltakerId = tiltaksdeltakerId,
+                )
+                tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
+                    eldsteHendelse,
+                    "melding1",
+                    TiltaksdeltakerHendelseKilde.Komet,
+                    nå(tac.clock).minusMinutes(40),
+                )
+
+                val mellomHendelse = getTiltaksdeltakerHendelse(
+                    sakId = sak.id,
+                    fom = deltakelseFom,
+                    tom = deltakelsesTom.plusMonths(1),
+                    tiltaksdeltakerId = tiltaksdeltakerId,
+                )
+                tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
+                    mellomHendelse,
+                    "melding2",
+                    TiltaksdeltakerHendelseKilde.Komet,
+                    nå(tac.clock).minusMinutes(30),
+                )
+
+                val nyesteHendelse = getTiltaksdeltakerHendelse(
+                    sakId = sak.id,
+                    fom = deltakelseFom,
+                    tom = deltakelsesTom.plusMonths(2),
+                    tiltaksdeltakerId = tiltaksdeltakerId,
+                )
+                tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
+                    nyesteHendelse,
+                    "melding3",
+                    TiltaksdeltakerHendelseKilde.Komet,
+                    nå(tac.clock).minusMinutes(20),
+                )
+
+                tac.endretTiltaksdeltakerJobb.håndterEndretTiltaksdeltakerHendelser()
+
+                val ubehandlede = tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede(nå(tac.clock))
+
+                // Alle tre skal være markert som behandlet
+                ubehandlede.none { it.id == eldsteHendelse.id } shouldBe true
+                ubehandlede.none { it.id == mellomHendelse.id } shouldBe true
+                ubehandlede.none { it.id == nyesteHendelse.id } shouldBe true
+
+                // De to eldste skal være ignorert (ingen oppgave eller behandling)
+                val oppdatertEldste = tac.tiltaksdeltakerHendelsePostgresRepo.hent(eldsteHendelse.id)!!
+                oppdatertEldste.oppgaveId.shouldBeNull()
+                oppdatertEldste.behandlingId.shouldBeNull()
+
+                val oppdatertMellom = tac.tiltaksdeltakerHendelsePostgresRepo.hent(mellomHendelse.id)!!
+                oppdatertMellom.oppgaveId.shouldBeNull()
+                oppdatertMellom.behandlingId.shouldBeNull()
+
+                // Kun nyeste skal ha blitt evaluert og fått revurdering
+                val oppdatertNyeste = tac.tiltaksdeltakerHendelsePostgresRepo.hent(nyesteHendelse.id)!!
+                oppdatertNyeste.behandlingId.shouldNotBeNull()
+
+                val sisteBehandling = tac.sakContext.sakRepo.hentForSakId(sak.id)!!.rammebehandlinger.last()
+                sisteBehandling.shouldBeInstanceOf<Revurdering>()
+                sisteBehandling.id shouldBe oppdatertNyeste.behandlingId
+            }
+        }
+
+        @Test
+        fun `hendelser for ulike deltakere behandles uavhengig`() {
+            withTestApplicationContextAndPostgres(runIsolated = true) { tac ->
+                val fnr = Fnr.random()
+                val førsteTiltaksdeltakerId = TiltaksdeltakerId.random()
+                val andreTiltaksdeltakerId = TiltaksdeltakerId.random()
+                val førsteEksternId = UUID.randomUUID().toString()
+                val andreEksternId = UUID.randomUUID().toString()
+                val deltakelseFom = 5.januar(2025)
+                val deltakelsesTom = 5.mai(2025)
+                val deltakelsesperiode = deltakelseFom til deltakelsesTom
+
+                val førsteTiltaksdeltakelse = tiltaksdeltakelse(
+                    periode = deltakelsesperiode,
+                    internDeltakelseId = førsteTiltaksdeltakerId,
+                    eksternTiltaksdeltakelseId = førsteEksternId,
+                )
+
+                val andreDeltakelsesperiode = 10.mai(2025) til 11.juni(2025)
+                val andreTiltaksdeltakelse = tiltaksdeltakelse(
+                    periode = andreDeltakelsesperiode,
+                    internDeltakelseId = andreTiltaksdeltakerId,
+                    eksternTiltaksdeltakelseId = andreEksternId,
+                )
+
+                val (sak) = iverksettSøknadsbehandling(
+                    tac = tac,
+                    fnr = fnr,
+                    innvilgelsesperioder = innvilgelsesperioder(deltakelsesperiode, førsteTiltaksdeltakelse),
+                    tiltaksdeltakelse = førsteTiltaksdeltakelse,
+                )
+
+                iverksettSøknadsbehandling(
+                    tac = tac,
+                    sakId = sak.id,
+                    innvilgelsesperioder = innvilgelsesperioder(andreDeltakelsesperiode, andreTiltaksdeltakelse),
+                    tiltaksdeltakelse = andreTiltaksdeltakelse,
+                )
+
+                // To hendelser for første deltaker - eldre skal ignoreres
+                val førsteEldreHendelse = getTiltaksdeltakerHendelse(
+                    id = førsteEksternId,
+                    sakId = sak.id,
+                    fom = deltakelseFom,
+                    tom = deltakelsesTom.plusWeeks(1),
+                    tiltaksdeltakerId = førsteTiltaksdeltakerId,
+                )
+                tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
+                    førsteEldreHendelse,
+                    "melding1",
+                    TiltaksdeltakerHendelseKilde.Komet,
+                    nå(tac.clock).minusMinutes(30),
+                )
+                val førsteNyesteHendelse = getTiltaksdeltakerHendelse(
+                    id = førsteEksternId,
+                    sakId = sak.id,
+                    fom = deltakelseFom,
+                    tom = deltakelsesTom.plusMonths(1),
+                    tiltaksdeltakerId = førsteTiltaksdeltakerId,
+                )
+                tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
+                    førsteNyesteHendelse,
+                    "melding2",
+                    TiltaksdeltakerHendelseKilde.Komet,
+                    nå(tac.clock).minusMinutes(20),
+                )
+
+                // Én hendelse for andre deltaker - skal evalueres normalt
+                val andreHendelse = getTiltaksdeltakerHendelse(
+                    id = andreEksternId,
+                    sakId = sak.id,
+                    fom = andreDeltakelsesperiode.fraOgMed,
+                    tom = andreDeltakelsesperiode.tilOgMed.minusDays(2),
+                    deltakerstatus = TiltakDeltakerstatus.Avbrutt,
+                    tiltaksdeltakerId = andreTiltaksdeltakerId,
+                )
+                tac.tiltaksdeltakerHendelsePostgresRepo.lagre(
+                    andreHendelse,
+                    "melding3",
+                    TiltaksdeltakerHendelseKilde.Komet,
+                    nå(tac.clock).minusMinutes(20),
+                )
+
+                tac.endretTiltaksdeltakerJobb.håndterEndretTiltaksdeltakerHendelser()
+
+                val ubehandlede = tac.tiltaksdeltakerHendelsePostgresRepo.hentUbehandlede(nå(tac.clock))
+                ubehandlede.none { it.id == førsteEldreHendelse.id } shouldBe true
+                ubehandlede.none { it.id == førsteNyesteHendelse.id } shouldBe true
+                ubehandlede.none { it.id == andreHendelse.id } shouldBe true
+
+                // Eldre hendelse for første deltaker skal være ignorert
+                val oppdatertFørsteEldre = tac.tiltaksdeltakerHendelsePostgresRepo.hent(førsteEldreHendelse.id)!!
+                oppdatertFørsteEldre.oppgaveId.shouldBeNull()
+                oppdatertFørsteEldre.behandlingId.shouldBeNull()
+
+                // Nyeste hendelse for første deltaker skal ha blitt evaluert og fått revurdering
+                val oppdatertFørsteNyeste = tac.tiltaksdeltakerHendelsePostgresRepo.hent(førsteNyesteHendelse.id)!!
+                oppdatertFørsteNyeste.behandlingId.shouldNotBeNull()
+
+                // Andre deltaker sin hendelse skal også ha blitt evaluert uavhengig
+                // Men siden første deltaker sin revurdering nå er en åpen behandling, vil andre deltaker få oppgave i stedet
+                val oppdatertAndre = tac.tiltaksdeltakerHendelsePostgresRepo.hent(andreHendelse.id)!!
+                oppdatertAndre.oppgaveId.shouldNotBeNull()
             }
         }
     }

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/repository/TiltaksdeltakerHendelseTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/repository/TiltaksdeltakerHendelseTest.kt
@@ -17,7 +17,6 @@ import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.TiltaksdeltakerId
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.Tiltakskilde
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelse
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelseId
-import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelseKilde
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.jobb.TiltaksdeltakerEndring
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
@@ -253,7 +252,6 @@ fun getTiltaksdeltakerHendelse(
     oppgaveId: OppgaveId? = null,
     oppgaveSistSjekket: LocalDateTime? = null,
     tiltaksdeltakerId: TiltaksdeltakerId = TiltaksdeltakerId.random(),
-    kilde: TiltaksdeltakerHendelseKilde = TiltaksdeltakerHendelseKilde.Komet,
 ) =
     TiltaksdeltakerHendelse(
         id = hendelseId,
@@ -268,5 +266,4 @@ fun getTiltaksdeltakerHendelse(
         oppgaveSistSjekket = oppgaveSistSjekket,
         internDeltakerId = tiltaksdeltakerId,
         behandlingId = null,
-        kilde = kilde,
     )

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/repository/TiltaksdeltakerKafkaDbTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/repository/TiltaksdeltakerKafkaDbTest.kt
@@ -15,6 +15,8 @@ import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.TiltakDeltakerstatu
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.Tiltaksdeltakelse
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.TiltaksdeltakerId
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.Tiltakskilde
+import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelse
+import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelseId
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.jobb.TiltaksdeltakerEndring
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
@@ -240,6 +242,7 @@ class TiltaksdeltakerKafkaDbTest {
 
 fun getTiltaksdeltakerKafkaDb(
     id: String = UUID.randomUUID().toString(),
+    hendelseId: TiltaksdeltakerHendelseId = TiltaksdeltakerHendelseId.random(),
     fom: LocalDate? = 5.januar(2025),
     tom: LocalDate? = 5.april(2025),
     dagerPerUke: Float? = 2.0F,
@@ -250,8 +253,9 @@ fun getTiltaksdeltakerKafkaDb(
     oppgaveSistSjekket: LocalDateTime? = null,
     tiltaksdeltakerId: TiltaksdeltakerId = TiltaksdeltakerId.random(),
 ) =
-    TiltaksdeltakerKafkaDb(
-        id = id,
+    TiltaksdeltakerHendelse(
+        id = hendelseId,
+        deltakerId = id,
         deltakelseFraOgMed = fom,
         deltakelseTilOgMed = tom,
         dagerPerUke = dagerPerUke,

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/repository/TiltaksdeltakerKafkaDbTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/repository/TiltaksdeltakerKafkaDbTest.kt
@@ -257,7 +257,7 @@ fun getTiltaksdeltakerHendelse(
 ) =
     TiltaksdeltakerHendelse(
         id = hendelseId,
-        deltakerId = id,
+        eksternDeltakerId = id,
         deltakelseFraOgMed = fom,
         deltakelseTilOgMed = tom,
         dagerPerUke = dagerPerUke,
@@ -266,7 +266,7 @@ fun getTiltaksdeltakerHendelse(
         sakId = sakId,
         oppgaveId = oppgaveId,
         oppgaveSistSjekket = oppgaveSistSjekket,
-        tiltaksdeltakerId = tiltaksdeltakerId,
+        internDeltakerId = tiltaksdeltakerId,
         behandlingId = null,
         kilde = kilde,
     )

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/repository/TiltaksdeltakerKafkaDbTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/tiltaksdeltakelse/infra/kafka/repository/TiltaksdeltakerKafkaDbTest.kt
@@ -17,13 +17,14 @@ import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.TiltaksdeltakerId
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.Tiltakskilde
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelse
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelseId
+import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.hendelse.TiltaksdeltakerHendelseKilde
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltakelse.infra.kafka.jobb.TiltaksdeltakerEndring
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
 
-class TiltaksdeltakerKafkaDbTest {
+class TiltaksdeltakerHendelseTest {
     private val lagretTiltaksdeltakelse =
         Tiltaksdeltakelse(
             eksternDeltakelseId = UUID.randomUUID().toString(),
@@ -44,18 +45,18 @@ class TiltaksdeltakerKafkaDbTest {
     @Test
     fun `tiltaksdeltakelseErEndret - ingen endring - returnerer ingen endringer`() {
         val clock = TikkendeKlokke()
-        val tiltaksdeltakerKafkaDb = getTiltaksdeltakerKafkaDb()
+        val tiltaksdeltakerHendelse = getTiltaksdeltakerHendelse()
 
-        tiltaksdeltakerKafkaDb.finnEndringer(lagretTiltaksdeltakelse, clock).shouldBeNull()
+        tiltaksdeltakerHendelse.finnEndringer(lagretTiltaksdeltakelse, clock).shouldBeNull()
     }
 
     @Test
     fun `tiltaksdeltakelseErEndret - endret startdato - returnerer ENDRET_STARTDATO`() {
         val clock = TikkendeKlokke()
         val nyStartdato = lagretTiltaksdeltakelse.deltakelseFraOgMed!!.minusDays(3)
-        val tiltaksdeltakerKafkaDb = getTiltaksdeltakerKafkaDb(fom = nyStartdato)
+        val tiltaksdeltakerHendelse = getTiltaksdeltakerHendelse(fom = nyStartdato)
 
-        val endringer = tiltaksdeltakerKafkaDb.finnEndringer(lagretTiltaksdeltakelse, clock).shouldNotBeNull()
+        val endringer = tiltaksdeltakerHendelse.finnEndringer(lagretTiltaksdeltakelse, clock).shouldNotBeNull()
         endringer shouldHaveSize 1
         endringer.first().shouldBeInstanceOf<TiltaksdeltakerEndring.EndretStartdato>()
         (endringer.first() as TiltaksdeltakerEndring.EndretStartdato).nyStartdato shouldBe nyStartdato
@@ -65,9 +66,9 @@ class TiltaksdeltakerKafkaDbTest {
     fun `tiltaksdeltakelseErEndret - forlengelse - returnerer FORLENGELSE`() {
         val clock = TikkendeKlokke()
         val nySluttdato = lagretTiltaksdeltakelse.deltakelseTilOgMed!!.plusMonths(1)
-        val tiltaksdeltakerKafkaDb = getTiltaksdeltakerKafkaDb(tom = nySluttdato)
+        val tiltaksdeltakerHendelse = getTiltaksdeltakerHendelse(tom = nySluttdato)
 
-        val endringer = tiltaksdeltakerKafkaDb.finnEndringer(lagretTiltaksdeltakelse, clock).shouldNotBeNull()
+        val endringer = tiltaksdeltakerHendelse.finnEndringer(lagretTiltaksdeltakelse, clock).shouldNotBeNull()
         endringer shouldHaveSize 1
         endringer.first().shouldBeInstanceOf<TiltaksdeltakerEndring.Forlengelse>()
         (endringer.first() as TiltaksdeltakerEndring.Forlengelse).nySluttdato shouldBe nySluttdato
@@ -76,9 +77,9 @@ class TiltaksdeltakerKafkaDbTest {
     @Test
     fun `tiltaksdeltakelseErEndret - endret dager pr uke - returnerer ENDRET_DELTAKELSESMENGDE`() {
         val clock = TikkendeKlokke()
-        val tiltaksdeltakerKafkaDb = getTiltaksdeltakerKafkaDb(dagerPerUke = 1F)
+        val tiltaksdeltakerHendelse = getTiltaksdeltakerHendelse(dagerPerUke = 1F)
 
-        val endringer = tiltaksdeltakerKafkaDb.finnEndringer(lagretTiltaksdeltakelse, clock).shouldNotBeNull()
+        val endringer = tiltaksdeltakerHendelse.finnEndringer(lagretTiltaksdeltakelse, clock).shouldNotBeNull()
         endringer shouldHaveSize 1
         endringer.first().shouldBeInstanceOf<TiltaksdeltakerEndring.EndretDeltakelsesmengde>()
     }
@@ -87,9 +88,9 @@ class TiltaksdeltakerKafkaDbTest {
     fun `tiltaksdeltakelseErEndret - endret deltakelsesmengde - returnerer ENDRET_DELTAKELSESMENGDE`() {
         val clock = TikkendeKlokke()
         val nyDeltakelsesprosent = 60F
-        val tiltaksdeltakerKafkaDb = getTiltaksdeltakerKafkaDb(deltakelsesprosent = nyDeltakelsesprosent)
+        val tiltaksdeltakerHendelse = getTiltaksdeltakerHendelse(deltakelsesprosent = nyDeltakelsesprosent)
 
-        val endringer = tiltaksdeltakerKafkaDb.finnEndringer(lagretTiltaksdeltakelse, clock).shouldNotBeNull()
+        val endringer = tiltaksdeltakerHendelse.finnEndringer(lagretTiltaksdeltakelse, clock).shouldNotBeNull()
         endringer shouldHaveSize 1
         endringer.first().shouldBeInstanceOf<TiltaksdeltakerEndring.EndretDeltakelsesmengde>()
         (endringer.first() as TiltaksdeltakerEndring.EndretDeltakelsesmengde).nyDeltakelsesprosent shouldBe nyDeltakelsesprosent
@@ -98,10 +99,10 @@ class TiltaksdeltakerKafkaDbTest {
     @Test
     fun `tiltaksdeltakelseErEndret - lagret deltakelsesmengde er 0 og mottatt er null - returnerer ingen endringer`() {
         val clock = TikkendeKlokke()
-        val tiltaksdeltakerKafkaDb = getTiltaksdeltakerKafkaDb(deltakelsesprosent = null)
+        val tiltaksdeltakerHendelse = getTiltaksdeltakerHendelse(deltakelsesprosent = null)
         val tiltaksdeltakelse = lagretTiltaksdeltakelse.copy(deltakelseProsent = 0.0F)
 
-        tiltaksdeltakerKafkaDb.finnEndringer(tiltaksdeltakelse, clock).shouldBeNull()
+        tiltaksdeltakerHendelse.finnEndringer(tiltaksdeltakelse, clock).shouldBeNull()
     }
 
     @Test
@@ -111,13 +112,13 @@ class TiltaksdeltakerKafkaDbTest {
             deltakelseFraOgMed = LocalDate.now(clock).minusMonths(3),
             deltakelseTilOgMed = LocalDate.now(clock).plusWeeks(1),
         )
-        val tiltaksdeltakerKafkaDb = getTiltaksdeltakerKafkaDb(
+        val tiltaksdeltakerHendelse = getTiltaksdeltakerHendelse(
             fom = tiltaksdeltakelse.deltakelseFraOgMed,
             tom = tiltaksdeltakelse.deltakelseTilOgMed!!.minusWeeks(2),
             deltakerstatus = TiltakDeltakerstatus.HarSluttet,
         )
 
-        val endringer = tiltaksdeltakerKafkaDb.finnEndringer(tiltaksdeltakelse, clock).shouldNotBeNull()
+        val endringer = tiltaksdeltakerHendelse.finnEndringer(tiltaksdeltakelse, clock).shouldNotBeNull()
         endringer shouldHaveSize 1
         endringer.first().shouldBeInstanceOf<TiltaksdeltakerEndring.AvbruttDeltakelse>()
     }
@@ -129,13 +130,13 @@ class TiltaksdeltakerKafkaDbTest {
             deltakelseFraOgMed = LocalDate.now(clock).minusMonths(3),
             deltakelseTilOgMed = LocalDate.now(clock).minusDays(1),
         )
-        val tiltaksdeltakerKafkaDb = getTiltaksdeltakerKafkaDb(
+        val tiltaksdeltakerHendelse = getTiltaksdeltakerHendelse(
             fom = tiltaksdeltakelse.deltakelseFraOgMed,
             tom = tiltaksdeltakelse.deltakelseTilOgMed,
             deltakerstatus = TiltakDeltakerstatus.Fullført,
         )
 
-        tiltaksdeltakerKafkaDb.finnEndringer(tiltaksdeltakelse, clock).shouldBeNull()
+        tiltaksdeltakerHendelse.finnEndringer(tiltaksdeltakelse, clock).shouldBeNull()
     }
 
     @Test
@@ -145,13 +146,13 @@ class TiltaksdeltakerKafkaDbTest {
             deltakelseFraOgMed = LocalDate.now(clock).minusDays(1),
             deltakelseTilOgMed = LocalDate.now(clock).plusMonths(3),
         )
-        val tiltaksdeltakerKafkaDb = getTiltaksdeltakerKafkaDb(
+        val tiltaksdeltakerHendelse = getTiltaksdeltakerHendelse(
             fom = tiltaksdeltakelse.deltakelseFraOgMed,
             tom = tiltaksdeltakelse.deltakelseTilOgMed,
             deltakerstatus = TiltakDeltakerstatus.Deltar,
         )
 
-        tiltaksdeltakerKafkaDb.finnEndringer(tiltaksdeltakelse, clock).shouldBeNull()
+        tiltaksdeltakerHendelse.finnEndringer(tiltaksdeltakelse, clock).shouldBeNull()
     }
 
     @Test
@@ -162,13 +163,13 @@ class TiltaksdeltakerKafkaDbTest {
             deltakelseTilOgMed = LocalDate.now(clock).plusMonths(3),
         )
         val nySluttdato = tiltaksdeltakelse.deltakelseTilOgMed?.plusWeeks(1)
-        val tiltaksdeltakerKafkaDb = getTiltaksdeltakerKafkaDb(
+        val tiltaksdeltakerHendelse = getTiltaksdeltakerHendelse(
             fom = tiltaksdeltakelse.deltakelseFraOgMed,
             tom = nySluttdato,
             deltakerstatus = TiltakDeltakerstatus.Deltar,
         )
 
-        val endringer = tiltaksdeltakerKafkaDb.finnEndringer(tiltaksdeltakelse, clock).shouldNotBeNull()
+        val endringer = tiltaksdeltakerHendelse.finnEndringer(tiltaksdeltakelse, clock).shouldNotBeNull()
         endringer shouldHaveSize 1
         endringer.first().shouldBeInstanceOf<TiltaksdeltakerEndring.Forlengelse>()
         (endringer.first() as TiltaksdeltakerEndring.Forlengelse).nySluttdato shouldBe nySluttdato
@@ -182,13 +183,13 @@ class TiltaksdeltakerKafkaDbTest {
             deltakelseTilOgMed = LocalDate.now(clock).plusWeeks(1),
         )
         val nyStatus = TiltakDeltakerstatus.Fullført
-        val tiltaksdeltakerKafkaDb = getTiltaksdeltakerKafkaDb(
+        val tiltaksdeltakerHendelse = getTiltaksdeltakerHendelse(
             fom = tiltaksdeltakelse.deltakelseFraOgMed,
             tom = tiltaksdeltakelse.deltakelseTilOgMed,
             deltakerstatus = nyStatus,
         )
 
-        val endringer = tiltaksdeltakerKafkaDb.finnEndringer(tiltaksdeltakelse, clock).shouldNotBeNull()
+        val endringer = tiltaksdeltakerHendelse.finnEndringer(tiltaksdeltakelse, clock).shouldNotBeNull()
         endringer shouldHaveSize 1
         endringer.first().shouldBeInstanceOf<TiltaksdeltakerEndring.EndretStatus>()
         (endringer.first() as TiltaksdeltakerEndring.EndretStatus).nyStatus shouldBe nyStatus
@@ -197,11 +198,11 @@ class TiltaksdeltakerKafkaDbTest {
     @Test
     fun `tiltaksdeltakelseErEndret - kun endret status til avbrutt - returnerer AVBRUTT_DELTAKELSE`() {
         val clock = TikkendeKlokke()
-        val tiltaksdeltakerKafkaDb = getTiltaksdeltakerKafkaDb(
+        val tiltaksdeltakerHendelse = getTiltaksdeltakerHendelse(
             deltakerstatus = TiltakDeltakerstatus.Avbrutt,
         )
 
-        val endringer = tiltaksdeltakerKafkaDb.finnEndringer(lagretTiltaksdeltakelse, clock).shouldNotBeNull()
+        val endringer = tiltaksdeltakerHendelse.finnEndringer(lagretTiltaksdeltakelse, clock).shouldNotBeNull()
         endringer shouldHaveSize 1
         endringer.first().shouldBeInstanceOf<TiltaksdeltakerEndring.AvbruttDeltakelse>()
     }
@@ -209,12 +210,12 @@ class TiltaksdeltakerKafkaDbTest {
     @Test
     fun `tiltaksdeltakelseErEndret - forlengelse og endret deltakelsesmengde - returnerer begge`() {
         val clock = TikkendeKlokke()
-        val tiltaksdeltakerKafkaDb = getTiltaksdeltakerKafkaDb(
+        val tiltaksdeltakerHendelse = getTiltaksdeltakerHendelse(
             tom = lagretTiltaksdeltakelse.deltakelseTilOgMed!!.plusMonths(1),
             dagerPerUke = 1F,
         )
 
-        val endringer = tiltaksdeltakerKafkaDb.finnEndringer(lagretTiltaksdeltakelse, clock).shouldNotBeNull()
+        val endringer = tiltaksdeltakerHendelse.finnEndringer(lagretTiltaksdeltakelse, clock).shouldNotBeNull()
         endringer.size shouldBe 2
         endringer.any { it is TiltaksdeltakerEndring.Forlengelse } shouldBe true
         endringer.any { it is TiltaksdeltakerEndring.EndretDeltakelsesmengde } shouldBe true
@@ -228,19 +229,19 @@ class TiltaksdeltakerKafkaDbTest {
             deltakelseTilOgMed = LocalDate.now(clock).plusMonths(4),
             deltakelseStatus = TiltakDeltakerstatus.VenterPåOppstart,
         )
-        val tiltaksdeltakerKafkaDb = getTiltaksdeltakerKafkaDb(
+        val tiltaksdeltakerHendelse = getTiltaksdeltakerHendelse(
             fom = null,
             tom = null,
             deltakerstatus = TiltakDeltakerstatus.IkkeAktuell,
         )
 
-        val endringer = tiltaksdeltakerKafkaDb.finnEndringer(tiltaksdeltakelse, clock).shouldNotBeNull()
+        val endringer = tiltaksdeltakerHendelse.finnEndringer(tiltaksdeltakelse, clock).shouldNotBeNull()
         endringer shouldHaveSize 1
         endringer.first().shouldBeInstanceOf<TiltaksdeltakerEndring.IkkeAktuellDeltakelse>()
     }
 }
 
-fun getTiltaksdeltakerKafkaDb(
+fun getTiltaksdeltakerHendelse(
     id: String = UUID.randomUUID().toString(),
     hendelseId: TiltaksdeltakerHendelseId = TiltaksdeltakerHendelseId.random(),
     fom: LocalDate? = 5.januar(2025),
@@ -252,6 +253,7 @@ fun getTiltaksdeltakerKafkaDb(
     oppgaveId: OppgaveId? = null,
     oppgaveSistSjekket: LocalDateTime? = null,
     tiltaksdeltakerId: TiltaksdeltakerId = TiltaksdeltakerId.random(),
+    kilde: TiltaksdeltakerHendelseKilde = TiltaksdeltakerHendelseKilde.Komet,
 ) =
     TiltaksdeltakerHendelse(
         id = hendelseId,
@@ -266,4 +268,5 @@ fun getTiltaksdeltakerKafkaDb(
         oppgaveSistSjekket = oppgaveSistSjekket,
         tiltaksdeltakerId = tiltaksdeltakerId,
         behandlingId = null,
+        kilde = kilde,
     )


### PR DESCRIPTION
Håndterer nå dersom flere hendelser for samme deltakelse skal føre til at oppgave eller revurdering opprettes. 

Forbedrer også sporbarhet for tiltaksdeltaker-hendelser:
- Lagrer nå alle hendelser for endret tiltaksdeltakelse, og markerer som behandlet istedenfor å slette hendelser som systemet anser som ikke relevante.
- Lagrer kilde for hendelsen