### PR TITLE
Validering av helgedager i meldeperioder

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  workflows: write
 
 jobs:
   dependabot:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -7,7 +7,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  workflows: write
 
 jobs:
   dependabot:

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/domene/KanIkkeIverksetteBehandling.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/domene/KanIkkeIverksetteBehandling.kt
@@ -13,4 +13,8 @@ sealed interface KanIkkeIverksetteBehandling {
     data class UtbetalingFeil(val feil: KanIkkeIverksetteUtbetaling, val sak: Sak, val behandling: Rammebehandling) : KanIkkeIverksetteBehandling
 
     data class OpprettVedtakFeil(val feil: OpprettRammevedtakFeil) : KanIkkeIverksetteBehandling
+
+    data object UgyldigeMeldeperioderHelg : KanIkkeIverksetteBehandling
+
+    data object VedtakErIkkeSisteVedtakPåSaken : KanIkkeIverksetteBehandling
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/domene/KanIkkeOppdatereBehandling.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/domene/KanIkkeOppdatereBehandling.kt
@@ -13,6 +13,8 @@ sealed interface KanIkkeOppdatereBehandling {
     data object ErPaVent : KanIkkeOppdatereBehandling
 
     data object KanIkkeOpphøre : KanIkkeOppdatereBehandling
+
+    data object UgyldigeMeldeperioderHelg : KanIkkeOppdatereBehandling
 }
 
 sealed interface KanIkkeOppdatereOmgjøring : KanIkkeOppdatereBehandling {

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/domene/SakValiderMeldeperioderHelgEx.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/domene/SakValiderMeldeperioderHelgEx.kt
@@ -17,7 +17,7 @@ fun Sak.harGyldigeMeldeperioderForHelg(behandlingId: RammebehandlingId, clock: C
 
     // Uten en vedtaksperiode (f.eks. når resultatet er "ikke valgt") finnes det ingen meldeperioder å validere.
     if (rammebehandling.vedtaksperiode == null) {
-        return true
+        return harGyldigeMeldeperioderForHelg()
     }
 
     return genererMeldeperioderForValidering(rammebehandling, clock)

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/domene/SakValiderMeldeperioderHelgEx.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/domene/SakValiderMeldeperioderHelgEx.kt
@@ -1,0 +1,49 @@
+package no.nav.tiltakspenger.saksbehandling.behandling.domene
+
+import no.nav.tiltakspenger.libs.common.RammebehandlingId
+import no.nav.tiltakspenger.libs.meldekort.MeldeperiodeKjedeId
+import no.nav.tiltakspenger.saksbehandling.felles.erHverdag
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.Meldeperiode
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.genererMeldeperioderForValidering
+import no.nav.tiltakspenger.saksbehandling.sak.Sak
+import java.time.Clock
+
+fun Sak.harGyldigeMeldeperioderForHelg(behandlingId: RammebehandlingId, clock: Clock): Boolean {
+    if (kanSendeInnHelgForMeldekort) {
+        return true
+    }
+
+    val rammebehandling = hentRammebehandling(behandlingId)!!
+
+    // Uten en vedtaksperiode (f.eks. når resultatet er "ikke valgt") finnes det ingen meldeperioder å validere.
+    if (rammebehandling.vedtaksperiode == null) {
+        return true
+    }
+
+    return genererMeldeperioderForValidering(rammebehandling, clock)
+        .hentMeldeperiodeKjederMedKunRettIHelg().isEmpty()
+}
+
+fun Sak.harGyldigeMeldeperioderForHelg(): Boolean {
+    return kanSendeInnHelgForMeldekort || meldeperiodeKjeder
+        .sisteMeldeperiodePerKjede
+        .hentMeldeperiodeKjederMedKunRettIHelg().isEmpty()
+}
+
+fun Sak.hentMeldeperiodeKjederMedKunRettIHelg(): List<MeldeperiodeKjedeId> {
+    return this.meldeperiodeKjeder.sisteMeldeperiodePerKjede.hentMeldeperiodeKjederMedKunRettIHelg()
+}
+
+private fun List<Meldeperiode>.hentMeldeperiodeKjederMedKunRettIHelg(): List<MeldeperiodeKjedeId> {
+    return this.mapNotNull { meldeperiode ->
+        val harRettPåMinstEnHverdag by lazy {
+            meldeperiode.periode.datoer.any { it.erHverdag() && meldeperiode.girRett[it] == true }
+        }
+
+        if (meldeperiode.ingenDagerGirRett || harRettPåMinstEnHverdag) {
+            return@mapNotNull null
+        }
+
+        meldeperiode.kjedeId
+    }
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/domene/søknadsbehandling/KanIkkeSendeRammebehandlingTilBeslutter.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/domene/søknadsbehandling/KanIkkeSendeRammebehandlingTilBeslutter.kt
@@ -15,4 +15,6 @@ sealed interface KanIkkeSendeRammebehandlingTilBeslutter {
     data class UtbetalingFeil(val feil: KanIkkeIverksetteUtbetaling, val sak: Sak, val behandling: Rammebehandling) : KanIkkeSendeRammebehandlingTilBeslutter
 
     data class SimuleringFeil(val feil: KunneIkkeSimulere) : KanIkkeSendeRammebehandlingTilBeslutter
+
+    data object UgyldigeMeldeperioderHelg : KanIkkeSendeRammebehandlingTilBeslutter
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/infra/route/ErrorMappers.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/infra/route/ErrorMappers.kt
@@ -70,4 +70,9 @@ internal fun KanIkkeOppdatereBehandling.tilStatusOgErrorJson(): Pair<HttpStatusC
         "For valgt hjemmel må vedtaket begrunnes med fritekst: ${this.hjemler}",
         "valgte_hjemler_krever_fritekst",
     )
+
+    KanIkkeOppdatereBehandling.UgyldigeMeldeperioderHelg -> HttpStatusCode.Conflict to ErrorJson(
+        "Behandlingen har meldeperioder med kun rett i helg, men saken er ikke markert for melding på helgedager",
+        "ugyldige_meldeperioder_for_helg",
+    )
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/infra/route/SendBehandlingTilBeslutningRoute.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/infra/route/SendBehandlingTilBeslutningRoute.kt
@@ -61,6 +61,8 @@ fun Route.sendRammebehandlingTilBeslutningRoute(
                         -> call.respondJson(statusAndValue = it.toErrorJson())
 
                         is KanIkkeSendeRammebehandlingTilBeslutter.UtbetalingFeil -> call.respondJson(it.toErrorJson())
+
+                        KanIkkeSendeRammebehandlingTilBeslutter.UgyldigeMeldeperioderHelg -> call.respondJson(it.toErrorJson())
                     }
                 }.onRight { (sak, behandling) ->
                     auditService.logMedRammebehandlingId(
@@ -104,4 +106,9 @@ private fun KanIkkeSendeRammebehandlingTilBeslutter.toErrorJson(): Pair<HttpStat
             data = this.sak.tilRammebehandlingDTO(this.behandling.id),
         )
     }
+
+    KanIkkeSendeRammebehandlingTilBeslutter.UgyldigeMeldeperioderHelg -> HttpStatusCode.Conflict to ErrorJson(
+        "Behandlingen har meldeperioder med kun rett i helg, men saken er ikke markert for melding på helgedager",
+        "ugyldige_meldeperioder_for_helg",
+    )
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/infra/route/iverksett/IverksettBehandlingRoute.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/infra/route/iverksett/IverksettBehandlingRoute.kt
@@ -90,6 +90,20 @@ private suspend fun ApplicationCall.handleIverksettFeil(feil: KanIkkeIverksetteB
         is KanIkkeIverksetteBehandling.OpprettVedtakFeil -> {
             respondJson(feil.feil.tilErrorJson())
         }
+
+        KanIkkeIverksetteBehandling.UgyldigeMeldeperioderHelg -> respondJson(
+            HttpStatusCode.Conflict to ErrorJson(
+                "Behandlingen har meldeperioder med kun rett i helg, men saken er ikke markert for melding på helgedager",
+                "ugyldige_meldeperioder_for_helg",
+            ),
+        )
+
+        KanIkkeIverksetteBehandling.VedtakErIkkeSisteVedtakPåSaken -> respondJson(
+            HttpStatusCode.Conflict to ErrorJson(
+                "Vedtaket som iverksettes må være det siste vedtaket på saken. Saken kan ha blitt endret av et nytt vedtak etter at behandlingen ble sendt til godkjenning, og må sendes tilbake for å vurderes på nytt.",
+                "vedtak_er_ikke_siste_vedtak_på_saken",
+            ),
+        )
     }
 }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/service/behandling/IverksettRammebehandlingService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/service/behandling/IverksettRammebehandlingService.kt
@@ -16,7 +16,6 @@ import no.nav.tiltakspenger.saksbehandling.behandling.domene.KanIkkeIverksetteBe
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.Rammebehandling
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.Revurdering
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.Søknadsbehandling
-import no.nav.tiltakspenger.saksbehandling.behandling.domene.harGyldigeMeldeperioderForHelg
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.resultat.Omgjøringsresultat
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.resultat.Revurderingsresultat
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.resultat.Søknadsbehandlingsresultat
@@ -28,6 +27,7 @@ import no.nav.tiltakspenger.saksbehandling.behandling.service.sak.SakService
 import no.nav.tiltakspenger.saksbehandling.felles.Attestering
 import no.nav.tiltakspenger.saksbehandling.felles.Attesteringsstatus
 import no.nav.tiltakspenger.saksbehandling.infra.metrikker.MetricRegister
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.harGyldigeMeldeperioderForHelg
 import no.nav.tiltakspenger.saksbehandling.meldekort.ports.MeldekortbehandlingRepo
 import no.nav.tiltakspenger.saksbehandling.meldekort.ports.MeldeperiodeRepo
 import no.nav.tiltakspenger.saksbehandling.sak.Sak

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/service/behandling/IverksettRammebehandlingService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/service/behandling/IverksettRammebehandlingService.kt
@@ -16,6 +16,7 @@ import no.nav.tiltakspenger.saksbehandling.behandling.domene.KanIkkeIverksetteBe
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.Rammebehandling
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.Revurdering
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.Søknadsbehandling
+import no.nav.tiltakspenger.saksbehandling.behandling.domene.harGyldigeMeldeperioderForHelg
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.resultat.Omgjøringsresultat
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.resultat.Revurderingsresultat
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.resultat.Søknadsbehandlingsresultat
@@ -109,12 +110,12 @@ class IverksettRammebehandlingService(
             is Revurdering -> oppdatertSak.iverksettRammebehandling(
                 rammevedtak = vedtak,
                 statistikkhendelser = (klagestatistikk + rammevedtakstatistikk),
-            )
+            ).getOrElse { return it.left() }
 
             is Søknadsbehandling -> oppdatertSak.iverksettSøknadsbehandling(
                 rammevedtak = vedtak,
                 statistikkhendelser = klagestatistikk + rammevedtakstatistikk,
-            )
+            ).getOrElse { return it.left() }
         }
 
         return (doubleOppdatertSak to iverksattRammebehandling).right()
@@ -123,7 +124,7 @@ class IverksettRammebehandlingService(
     private suspend fun Sak.iverksettSøknadsbehandling(
         rammevedtak: Rammevedtak,
         statistikkhendelser: Statistikkhendelser,
-    ): Sak {
+    ): Either<KanIkkeIverksetteBehandling, Sak> {
         return when (rammevedtak.rammebehandlingsresultat) {
             is Søknadsbehandlingsresultat.Innvilgelse -> this.iverksettRammebehandling(
                 rammevedtak,
@@ -147,7 +148,7 @@ class IverksettRammebehandlingService(
                         tx.onSuccess { MetricRegister.IVERKSATT_BEHANDLING.inc() }
                     }
                 }
-                this
+                this.right()
             }
 
             is Revurderingsresultat -> throw IllegalArgumentException("Kan ikke iverksette revurdering-resultat på en søknadsbehandling")
@@ -157,7 +158,7 @@ class IverksettRammebehandlingService(
     private suspend fun Sak.iverksettRammebehandling(
         rammevedtak: Rammevedtak,
         statistikkhendelser: Statistikkhendelser,
-    ): Sak {
+    ): Either<KanIkkeIverksetteBehandling, Sak> {
         when (rammevedtak.rammebehandlingsresultat) {
             is Omgjøringsresultat.OmgjøringIkkeValgt,
             is Søknadsbehandlingsresultat.Avslag,
@@ -171,11 +172,18 @@ class IverksettRammebehandlingService(
             -> Unit
         }
 
-        require(this.rammevedtaksliste.last().id == rammevedtak.id) {
-            "Vedtaket som iverksettes må være siste vedtak på saken (forventet at ${rammevedtak.id} skal være siste vedtak på ${this.id})"
+        if (this.rammevedtaksliste.last().id != rammevedtak.id) {
+            logger.error { "Vedtaket som iverksettes må være siste vedtak på saken (forventet at ${rammevedtak.id} skal være siste vedtak på ${this.id})" }
+            return KanIkkeIverksetteBehandling.VedtakErIkkeSisteVedtakPåSaken.left()
         }
 
         val (sakOppdatertMedMeldeperioder, oppdaterteMeldeperioder) = this.genererMeldeperioder(clock)
+
+        if (!sakOppdatertMedMeldeperioder.harGyldigeMeldeperioderForHelg()) {
+            logger.error { "Kan ikke iverksette rammebehandling med ugyldige meldeperioder for helg" }
+            return KanIkkeIverksetteBehandling.UgyldigeMeldeperioderHelg.left()
+        }
+
         val (oppdaterteMeldekortbehandlinger, oppdaterteMeldekort) = this.meldekortbehandlinger.oppdaterMedNyeKjeder(
             oppdaterteKjeder = sakOppdatertMedMeldeperioder.meldeperiodeKjeder,
             clock = clock,
@@ -220,6 +228,6 @@ class IverksettRammebehandlingService(
             }
         }
 
-        return sakOppdatertMedMeldekortbehandlinger
+        return sakOppdatertMedMeldekortbehandlinger.right()
     }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/service/behandling/IverksettRammebehandlingService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/service/behandling/IverksettRammebehandlingService.kt
@@ -12,6 +12,7 @@ import no.nav.tiltakspenger.libs.common.SakId
 import no.nav.tiltakspenger.libs.common.Saksbehandler
 import no.nav.tiltakspenger.libs.common.nå
 import no.nav.tiltakspenger.libs.persistering.domene.SessionFactory
+import no.nav.tiltakspenger.libs.persistering.domene.TransactionContext
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.KanIkkeIverksetteBehandling
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.Rammebehandling
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.Revurdering
@@ -19,7 +20,6 @@ import no.nav.tiltakspenger.saksbehandling.behandling.domene.Søknadsbehandling
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.resultat.Omgjøringsresultat
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.resultat.Revurderingsresultat
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.resultat.Søknadsbehandlingsresultat
-import no.nav.tiltakspenger.saksbehandling.behandling.infra.route.dto.tilRammebehandlingResultatTypeDTO
 import no.nav.tiltakspenger.saksbehandling.behandling.ports.RammebehandlingRepo
 import no.nav.tiltakspenger.saksbehandling.behandling.ports.RammevedtakRepo
 import no.nav.tiltakspenger.saksbehandling.behandling.service.OppdaterBeregningOgSimuleringService
@@ -27,7 +27,7 @@ import no.nav.tiltakspenger.saksbehandling.behandling.service.sak.SakService
 import no.nav.tiltakspenger.saksbehandling.felles.Attestering
 import no.nav.tiltakspenger.saksbehandling.felles.Attesteringsstatus
 import no.nav.tiltakspenger.saksbehandling.infra.metrikker.MetricRegister
-import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.harGyldigeMeldeperioderForHelg
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.meldeperioderErGyldigeForHelg
 import no.nav.tiltakspenger.saksbehandling.meldekort.ports.MeldekortbehandlingRepo
 import no.nav.tiltakspenger.saksbehandling.meldekort.ports.MeldeperiodeRepo
 import no.nav.tiltakspenger.saksbehandling.sak.Sak
@@ -107,7 +107,7 @@ class IverksettRammebehandlingService(
             }
 
         val doubleOppdatertSak = when (iverksattRammebehandling) {
-            is Revurdering -> oppdatertSak.iverksettRammebehandling(
+            is Revurdering -> oppdatertSak.iverksettRammebehandlingMedTidslinje(
                 rammevedtak = vedtak,
                 statistikkhendelser = (klagestatistikk + rammevedtakstatistikk),
             ).getOrElse { return it.left() }
@@ -126,43 +126,48 @@ class IverksettRammebehandlingService(
         statistikkhendelser: Statistikkhendelser,
     ): Either<KanIkkeIverksetteBehandling, Sak> {
         return when (rammevedtak.rammebehandlingsresultat) {
-            is Søknadsbehandlingsresultat.Innvilgelse -> this.iverksettRammebehandling(
+            is Søknadsbehandlingsresultat.Innvilgelse -> this.iverksettRammebehandlingMedTidslinje(
                 rammevedtak,
                 statistikkhendelser,
             )
 
-            is Søknadsbehandlingsresultat.Avslag -> {
-                val statistikkDTO = statistikkService.generer(statistikkhendelser)
-                // journalføring og dokumentdistribusjon skjer i egen jobb
-                sessionFactory.withTransactionContext { tx ->
-                    // Obs: Dersom du endrer eller legger til noe her som angår klage, merk at du må gjøre tilsvarende i [no.nav.tiltakspenger.saksbehandling.klage.service.IverksettAvvistKlagebehandlingService]
-                    rammebehandlingRepo.lagre(rammevedtak.rammebehandling, tx)
-
-                    sakService.markerSkalSendesTilMeldekortApi(
-                        sakId = this.id,
-                        sessionContext = tx,
-                    )
-                    rammevedtakRepo.lagre(rammevedtak, tx)
-                    statistikkService.lagre(statistikkDTO, tx)
-                    runBlocking {
-                        tx.onSuccess { MetricRegister.IVERKSATT_BEHANDLING.inc() }
-                    }
-                }
-                this.right()
-            }
+            is Søknadsbehandlingsresultat.Avslag -> this.iverksettAvslag(rammevedtak, statistikkhendelser)
 
             is Revurderingsresultat -> throw IllegalArgumentException("Kan ikke iverksette revurdering-resultat på en søknadsbehandling")
         }
     }
 
-    private suspend fun Sak.iverksettRammebehandling(
+    /**
+     *  Avslag påvirker ikke sakens tidslinje og meldeperioder, og har derfor en enklere iverksetting
+     * */
+    private suspend fun Sak.iverksettAvslag(
+        rammevedtak: Rammevedtak,
+        statistikkhendelser: Statistikkhendelser,
+    ): Either<KanIkkeIverksetteBehandling, Sak> {
+        lagreIverksattVedtak(
+            rammevedtak = rammevedtak,
+            statistikkhendelser = statistikkhendelser,
+            tilleggsoperasjoner = { tx ->
+                sakService.markerSkalSendesTilMeldekortApi(
+                    sakId = this.id,
+                    sessionContext = tx,
+                )
+            },
+        )
+        return this.right()
+    }
+
+    /**
+     *  Iverksetter en rammebehandling som påvirker sakens tidslinje
+     * */
+    private suspend fun Sak.iverksettRammebehandlingMedTidslinje(
         rammevedtak: Rammevedtak,
         statistikkhendelser: Statistikkhendelser,
     ): Either<KanIkkeIverksetteBehandling, Sak> {
         when (rammevedtak.rammebehandlingsresultat) {
             is Omgjøringsresultat.OmgjøringIkkeValgt,
             is Søknadsbehandlingsresultat.Avslag,
-            -> throw IllegalArgumentException("Kan ikke iverksette en behandling med resultat ${rammevedtak.rammebehandlingsresultat.tilRammebehandlingResultatTypeDTO()}")
+            -> throw IllegalArgumentException("Kan ikke iverksette en behandling med resultat ${rammevedtak.rammebehandlingsresultat::class.simpleName}")
 
             is Omgjøringsresultat.OmgjøringInnvilgelse,
             is Revurderingsresultat.Innvilgelse,
@@ -172,15 +177,20 @@ class IverksettRammebehandlingService(
             -> Unit
         }
 
+        // Denne skal ikke være mulig å treffe
         if (this.rammevedtaksliste.last().id != rammevedtak.id) {
-            logger.error { "Vedtaket som iverksettes må være siste vedtak på saken (forventet at ${rammevedtak.id} skal være siste vedtak på ${this.id})" }
+            logger.error(RuntimeException("Trigger stacktrace for enklere debug")) {
+                "Vedtaket som iverksettes må være siste vedtak på saken (forventet at ${rammevedtak.id} skal være siste vedtak på ${this.id})"
+            }
             return KanIkkeIverksetteBehandling.VedtakErIkkeSisteVedtakPåSaken.left()
         }
 
         val (sakOppdatertMedMeldeperioder, oppdaterteMeldeperioder) = this.genererMeldeperioder(clock)
 
-        if (!sakOppdatertMedMeldeperioder.harGyldigeMeldeperioderForHelg()) {
-            logger.error { "Kan ikke iverksette rammebehandling med ugyldige meldeperioder for helg" }
+        if (!sakOppdatertMedMeldeperioder.meldeperioderErGyldigeForHelg()) {
+            logger.error(RuntimeException("Trigger stacktrace for enklere debug")) {
+                "Kan ikke iverksette rammebehandling med ugyldige meldeperioder for helg"
+            }
             return KanIkkeIverksetteBehandling.UgyldigeMeldeperioderHelg.left()
         }
 
@@ -192,42 +202,66 @@ class IverksettRammebehandlingService(
             sakOppdatertMedMeldeperioder.oppdaterMeldekortbehandlinger(oppdaterteMeldekortbehandlinger)
 
         val tidligereVedtak = sakOppdatertMedMeldekortbehandlinger.rammevedtaksliste
-        val statistikkDTO = statistikkService.generer(statistikkhendelser)
+
+        lagreIverksattVedtak(
+            rammevedtak = rammevedtak,
+            statistikkhendelser = statistikkhendelser,
+            tilleggsoperasjoner = { tx ->
+                sakService.oppdaterSkalSendeMeldeperioderTilDatadelingOgSkalSendesTilMeldekortApi(
+                    sakId = sakOppdatertMedMeldeperioder.id,
+                    skalSendesTilMeldekortApi = true,
+                    skalSendeMeldeperioderTilDatadeling = true,
+                    sessionContext = tx,
+                )
+                meldeperiodeRepo.lagre(oppdaterteMeldeperioder, tx)
+                // Merk at simuleringen vil nulles ut her. Gjelder kun åpne meldekortbehandlinger.
+                oppdaterteMeldekort.forEach { meldekortbehandlingRepo.oppdater(it, null, tx) }
+
+                tidligereVedtak.forEach {
+                    rammevedtakRepo.oppdaterOmgjortAv(
+                        it.id,
+                        it.omgjortAvRammevedtak,
+                        tx,
+                    )
+                }
+            },
+            onSuccess = {
+                if (rammevedtak.rammebehandling.utbetaling?.harFeilutbetaling() == true) {
+                    logger.warn { "Rammebehandling med feilutbetaling har blitt iverksatt - Behandling-id ${rammevedtak.rammebehandling.id} - vedtak-id: ${rammevedtak.id} - sak-id: ${rammevedtak.sakId}" }
+                    MetricRegister.IVERKSATT_RAMMEBEHANDLING_MED_FEILUTBETALING.inc()
+                }
+            },
+        )
+
+        return sakOppdatertMedMeldekortbehandlinger.right()
+    }
+
+    /**
+     *  Dersom du endrer eller legger til noe her som angår klage, merk at du må gjøre tilsvarende i
+     *  [no.nav.tiltakspenger.saksbehandling.klage.service.IverksettAvvistKlagebehandlingService]
+     *
+     *  Journalføring og dokumentdistribusjon skjer i egen jobb
+     */
+    private suspend fun lagreIverksattVedtak(
+        rammevedtak: Rammevedtak,
+        statistikkhendelser: Statistikkhendelser,
+        tilleggsoperasjoner: (tx: TransactionContext) -> Unit,
+        onSuccess: () -> Unit = {},
+    ) {
         // journalføring og dokumentdistribusjon skjer i egen jobb
+
+        val statistikkDTO = statistikkService.generer(statistikkhendelser)
         sessionFactory.withTransactionContext { tx ->
-            // Obs: Dersom du endrer eller legger til noe her som angår klage, merk at du må gjøre tilsvarende i [no.nav.tiltakspenger.saksbehandling.klage.service.IverksettAvvistKlagebehandlingService]
             rammebehandlingRepo.lagre(rammevedtak.rammebehandling, tx)
-            sakService.oppdaterSkalSendeMeldeperioderTilDatadelingOgSkalSendesTilMeldekortApi(
-                sakId = sakOppdatertMedMeldeperioder.id,
-                skalSendesTilMeldekortApi = true,
-                skalSendeMeldeperioderTilDatadeling = true,
-                sessionContext = tx,
-            )
             rammevedtakRepo.lagre(rammevedtak, tx)
             statistikkService.lagre(statistikkDTO, tx)
-            meldeperiodeRepo.lagre(oppdaterteMeldeperioder, tx)
-            // Merk at simuleringen vil nulles ut her. Gjelder kun åpne meldekortbehandlinger.
-            oppdaterteMeldekort.forEach { meldekortbehandlingRepo.oppdater(it, null, tx) }
-
-            tidligereVedtak.forEach {
-                rammevedtakRepo.oppdaterOmgjortAv(
-                    it.id,
-                    it.omgjortAvRammevedtak,
-                    tx,
-                )
-            }
+            tilleggsoperasjoner(tx)
             runBlocking {
                 tx.onSuccess {
                     MetricRegister.IVERKSATT_BEHANDLING.inc()
-
-                    if (rammevedtak.rammebehandling.utbetaling?.harFeilutbetaling() == true) {
-                        logger.warn { "Rammebehandling med feilutbetaling har blitt iverksatt - Behandling-id ${rammevedtak.rammebehandling.id} - vedtak-id: ${rammevedtak.id} - sak-id: ${rammevedtak.sakId}" }
-                        MetricRegister.IVERKSATT_RAMMEBEHANDLING_MED_FEILUTBETALING.inc()
-                    }
+                    onSuccess()
                 }
             }
         }
-
-        return sakOppdatertMedMeldekortbehandlinger.right()
     }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/service/behandling/OppdaterRammebehandlingService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/service/behandling/OppdaterRammebehandlingService.kt
@@ -18,13 +18,13 @@ import no.nav.tiltakspenger.saksbehandling.behandling.domene.OppdaterSøknadsbeh
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.Rammebehandling
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.Revurdering
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.Søknadsbehandling
-import no.nav.tiltakspenger.saksbehandling.behandling.domene.harGyldigeMeldeperioderForHelg
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.oppdaterOmgjøring
 import no.nav.tiltakspenger.saksbehandling.behandling.ports.RammebehandlingRepo
 import no.nav.tiltakspenger.saksbehandling.behandling.service.sak.SakService
 import no.nav.tiltakspenger.saksbehandling.beregning.beregnInnvilgelse
 import no.nav.tiltakspenger.saksbehandling.beregning.beregnOpphør
 import no.nav.tiltakspenger.saksbehandling.beregning.beregnRevurderingStans
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.harGyldigeMeldeperioderForHelg
 import no.nav.tiltakspenger.saksbehandling.omgjøring.OmgjørRammevedtak
 import no.nav.tiltakspenger.saksbehandling.oppfølgingsenhet.NavkontorService
 import no.nav.tiltakspenger.saksbehandling.sak.Sak

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/service/behandling/OppdaterRammebehandlingService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/service/behandling/OppdaterRammebehandlingService.kt
@@ -18,6 +18,7 @@ import no.nav.tiltakspenger.saksbehandling.behandling.domene.OppdaterSøknadsbeh
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.Rammebehandling
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.Revurdering
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.Søknadsbehandling
+import no.nav.tiltakspenger.saksbehandling.behandling.domene.harGyldigeMeldeperioderForHelg
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.oppdaterOmgjøring
 import no.nav.tiltakspenger.saksbehandling.behandling.ports.RammebehandlingRepo
 import no.nav.tiltakspenger.saksbehandling.behandling.service.sak.SakService
@@ -66,6 +67,10 @@ class OppdaterRammebehandlingService(
             is OppdaterRevurderingKommando -> sak.oppdaterRevurdering(kommando, utbetaling)
         }.map { oppdatertBehandling: Rammebehandling ->
             val oppdatertSak = sak.oppdaterRammebehandling(oppdatertBehandling)
+
+            if (!oppdatertSak.harGyldigeMeldeperioderForHelg(oppdatertBehandling.id, clock)) {
+                return KanIkkeOppdatereBehandling.UgyldigeMeldeperioderHelg.left()
+            }
 
             log.debug { "Lagrer oppdatert behandling ${behandling.id} for sak ${behandling.sakId}" }
             sessionFactory.withTransactionContext { tx ->

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/service/behandling/OppdaterRammebehandlingService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/service/behandling/OppdaterRammebehandlingService.kt
@@ -24,7 +24,7 @@ import no.nav.tiltakspenger.saksbehandling.behandling.service.sak.SakService
 import no.nav.tiltakspenger.saksbehandling.beregning.beregnInnvilgelse
 import no.nav.tiltakspenger.saksbehandling.beregning.beregnOpphør
 import no.nav.tiltakspenger.saksbehandling.beregning.beregnRevurderingStans
-import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.harGyldigeMeldeperioderForHelg
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.meldeperioderErGyldigeForHelg
 import no.nav.tiltakspenger.saksbehandling.omgjøring.OmgjørRammevedtak
 import no.nav.tiltakspenger.saksbehandling.oppfølgingsenhet.NavkontorService
 import no.nav.tiltakspenger.saksbehandling.sak.Sak
@@ -68,7 +68,7 @@ class OppdaterRammebehandlingService(
         }.map { oppdatertBehandling: Rammebehandling ->
             val oppdatertSak = sak.oppdaterRammebehandling(oppdatertBehandling)
 
-            if (!oppdatertSak.harGyldigeMeldeperioderForHelg(oppdatertBehandling.id, clock)) {
+            if (!oppdatertSak.meldeperioderErGyldigeForHelg(oppdatertBehandling.id, clock)) {
                 return KanIkkeOppdatereBehandling.UgyldigeMeldeperioderHelg.left()
             }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/service/behandling/SendRammebehandlingTilBeslutningService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/service/behandling/SendRammebehandlingTilBeslutningService.kt
@@ -7,11 +7,11 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.tiltakspenger.libs.persistering.domene.SessionFactory
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.Rammebehandling
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.SendBehandlingTilBeslutningKommando
-import no.nav.tiltakspenger.saksbehandling.behandling.domene.harGyldigeMeldeperioderForHelg
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.søknadsbehandling.KanIkkeSendeRammebehandlingTilBeslutter
 import no.nav.tiltakspenger.saksbehandling.behandling.ports.RammebehandlingRepo
 import no.nav.tiltakspenger.saksbehandling.behandling.service.OppdaterBeregningOgSimuleringService
 import no.nav.tiltakspenger.saksbehandling.behandling.service.sak.SakService
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.harGyldigeMeldeperioderForHelg
 import no.nav.tiltakspenger.saksbehandling.sak.Sak
 import no.nav.tiltakspenger.saksbehandling.statistikk.StatistikkService
 import no.nav.tiltakspenger.saksbehandling.statistikk.Statistikkhendelser

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/service/behandling/SendRammebehandlingTilBeslutningService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/service/behandling/SendRammebehandlingTilBeslutningService.kt
@@ -11,7 +11,7 @@ import no.nav.tiltakspenger.saksbehandling.behandling.domene.søknadsbehandling.
 import no.nav.tiltakspenger.saksbehandling.behandling.ports.RammebehandlingRepo
 import no.nav.tiltakspenger.saksbehandling.behandling.service.OppdaterBeregningOgSimuleringService
 import no.nav.tiltakspenger.saksbehandling.behandling.service.sak.SakService
-import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.harGyldigeMeldeperioderForHelg
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.meldeperioderErGyldigeForHelg
 import no.nav.tiltakspenger.saksbehandling.sak.Sak
 import no.nav.tiltakspenger.saksbehandling.statistikk.StatistikkService
 import no.nav.tiltakspenger.saksbehandling.statistikk.Statistikkhendelser
@@ -65,7 +65,7 @@ class SendRammebehandlingTilBeslutningService(
             ).left()
         }
 
-        if (!sak.harGyldigeMeldeperioderForHelg(behandlingId, clock)) {
+        if (!sak.meldeperioderErGyldigeForHelg(behandlingId, clock)) {
             return KanIkkeSendeRammebehandlingTilBeslutter.UgyldigeMeldeperioderHelg.left()
         }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/service/behandling/SendRammebehandlingTilBeslutningService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/service/behandling/SendRammebehandlingTilBeslutningService.kt
@@ -7,6 +7,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.tiltakspenger.libs.persistering.domene.SessionFactory
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.Rammebehandling
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.SendBehandlingTilBeslutningKommando
+import no.nav.tiltakspenger.saksbehandling.behandling.domene.harGyldigeMeldeperioderForHelg
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.søknadsbehandling.KanIkkeSendeRammebehandlingTilBeslutter
 import no.nav.tiltakspenger.saksbehandling.behandling.ports.RammebehandlingRepo
 import no.nav.tiltakspenger.saksbehandling.behandling.service.OppdaterBeregningOgSimuleringService
@@ -62,6 +63,10 @@ class SendRammebehandlingTilBeslutningService(
                 oppdaterSak,
                 behandlingMedUtbetalingskontroll,
             ).left()
+        }
+
+        if (!sak.harGyldigeMeldeperioderForHelg(behandlingId, clock)) {
+            return KanIkkeSendeRammebehandlingTilBeslutter.UgyldigeMeldeperioderHelg.left()
         }
 
         return behandlingMedUtbetalingskontroll.tilBeslutning(

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/service/sak/KunneIkkeOppdatereHelgForMeldekort.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/service/sak/KunneIkkeOppdatereHelgForMeldekort.kt
@@ -1,0 +1,7 @@
+package no.nav.tiltakspenger.saksbehandling.behandling.service.sak
+
+import no.nav.tiltakspenger.libs.meldekort.MeldeperiodeKjedeId
+
+sealed interface KunneIkkeOppdatereHelgForMeldekort {
+    data class HarMeldeperioderMedKunHelg(val kjedeIder: List<MeldeperiodeKjedeId>) : KunneIkkeOppdatereHelgForMeldekort
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/service/sak/SakService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/service/sak/SakService.kt
@@ -15,6 +15,7 @@ import no.nav.tiltakspenger.libs.persistering.domene.SessionFactory
 import no.nav.tiltakspenger.libs.personklient.pdl.dto.ForelderBarnRelasjonRolle
 import no.nav.tiltakspenger.libs.personklient.skjerming.FellesSkjermingsklient
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.Behandlinger
+import no.nav.tiltakspenger.saksbehandling.behandling.domene.hentMeldeperiodeKjederMedKunRettIHelg
 import no.nav.tiltakspenger.saksbehandling.behandling.ports.SakRepo
 import no.nav.tiltakspenger.saksbehandling.behandling.service.person.KunneIkkeHenteEnkelPerson
 import no.nav.tiltakspenger.saksbehandling.behandling.service.person.PersonService
@@ -186,20 +187,37 @@ class SakService(
         )
     }
 
-    fun oppdaterKanSendeInnHelgForMeldekort(sakId: SakId, kanSendeHelg: Boolean): Sak {
+    fun oppdaterKanSendeInnHelgForMeldekort(
+        sakId: SakId,
+        kanSendeHelg: Boolean,
+    ): Either<KunneIkkeOppdatereHelgForMeldekort, Sak> {
         val sak = sakRepo.hentForSakId(sakId)
             ?: throw IkkeFunnetException("Fant ikke sak med saksnummer $sakId")
+
+        if (!kanSendeHelg) {
+            val kjederMedKunRettIHelg = sak.hentMeldeperiodeKjederMedKunRettIHelg()
+
+            if (kjederMedKunRettIHelg.isNotEmpty()) {
+                return KunneIkkeOppdatereHelgForMeldekort.HarMeldeperioderMedKunHelg(
+                    kjederMedKunRettIHelg,
+                ).left()
+            }
+        }
 
         val oppdatertSak = sak.oppdaterKanSendeInnHelgForMeldekort(kanSendeHelg)
 
         sessionFactory.withTransactionContext {
-            sakRepo.oppdaterKanSendeInnHelgForMeldekort(sakId = oppdatertSak.id, oppdatertSak.kanSendeInnHelgForMeldekort, it)
+            sakRepo.oppdaterKanSendeInnHelgForMeldekort(
+                sakId = oppdatertSak.id,
+                oppdatertSak.kanSendeInnHelgForMeldekort,
+                it,
+            )
             sakRepo.markerSkalSendesTilMeldekortApi(
                 sakId = oppdatertSak.id,
                 sessionContext = it,
             )
         }
 
-        return oppdatertSak
+        return oppdatertSak.right()
     }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/service/sak/SakService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/service/sak/SakService.kt
@@ -15,12 +15,12 @@ import no.nav.tiltakspenger.libs.persistering.domene.SessionFactory
 import no.nav.tiltakspenger.libs.personklient.pdl.dto.ForelderBarnRelasjonRolle
 import no.nav.tiltakspenger.libs.personklient.skjerming.FellesSkjermingsklient
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.Behandlinger
-import no.nav.tiltakspenger.saksbehandling.behandling.domene.hentMeldeperiodeKjederMedKunRettIHelg
 import no.nav.tiltakspenger.saksbehandling.behandling.ports.SakRepo
 import no.nav.tiltakspenger.saksbehandling.behandling.service.person.KunneIkkeHenteEnkelPerson
 import no.nav.tiltakspenger.saksbehandling.behandling.service.person.PersonService
 import no.nav.tiltakspenger.saksbehandling.felles.exceptions.IkkeFunnetException
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.MeldeperiodeKjeder
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.hentMeldeperiodeKjederMedKunRettIHelg
 import no.nav.tiltakspenger.saksbehandling.person.BarnMedSkjerming
 import no.nav.tiltakspenger.saksbehandling.person.EnkelPersonMedSkjerming
 import no.nav.tiltakspenger.saksbehandling.sak.Sak

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/service/sak/SakService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/service/sak/SakService.kt
@@ -192,7 +192,7 @@ class SakService(
         kanSendeHelg: Boolean,
     ): Either<KunneIkkeOppdatereHelgForMeldekort, Sak> {
         val sak = sakRepo.hentForSakId(sakId)
-            ?: throw IkkeFunnetException("Fant ikke sak med saksnummer $sakId")
+            ?: throw IkkeFunnetException("Fant ikke sak med sakId $sakId")
 
         if (!kanSendeHelg) {
             val kjederMedKunRettIHelg = sak.hentMeldeperiodeKjederMedKunRettIHelg()

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldeperiode/GenererMeldeperioderEx.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldeperiode/GenererMeldeperioderEx.kt
@@ -135,7 +135,7 @@ private fun MeldeperiodeKjeder.genererMeldeperioder(
             val antallDagerFraVedtak = hentAntallDager(periode)?.value ?: 0
             val antallDagerForPeriode = min(antallDagerFraTidslinje, antallDagerFraVedtak)
 
-            val version = hentMeldeperiodeKjedeForPeriode(periode)?.nesteVersjon()
+            val meldeperiodeVersjon = hentMeldeperiodeKjedeForPeriode(periode)?.nesteVersjon()
                 ?: HendelseVersjon.ny()
 
             Meldeperiode.opprettMeldeperiode(
@@ -145,7 +145,7 @@ private fun MeldeperiodeKjeder.genererMeldeperioder(
                 saksnummer = saksnummer,
                 sakId = sakId,
                 antallDagerForPeriode = antallDagerForPeriode,
-                versjon = version,
+                versjon = meldeperiodeVersjon,
                 rammevedtak = hentVedtakIder(periode),
                 clock = clock,
             )

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldeperiode/GenererMeldeperioderEx.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldeperiode/GenererMeldeperioderEx.kt
@@ -28,7 +28,7 @@ typealias OppdaterteKjederOgMeldeperioder = Pair<MeldeperiodeKjeder, List<Meldep
 /**
  *  Genererer hypotetiske meldeperioder ut fra en ikke-vedtatt behandling.
  *
- *  Skal kun benyttes for validering/testing, ikke for å generere faktiske meldeperioder som persisteres!
+ *  Skal kun benyttes for validering/testing, ikke for å generere faktiske meldeperioder som persisteres
  * */
 fun Sak.genererMeldeperioderForValidering(rammebehandling: Rammebehandling, clock: Clock): List<Meldeperiode> {
     val vedtaksperiode = rammebehandling.vedtaksperiode
@@ -88,7 +88,7 @@ fun Sak.genererMeldeperioderForValidering(rammebehandling: Rammebehandling, cloc
     )
 }
 
-fun MeldeperiodeKjeder.genererMeldeperioder(
+fun MeldeperiodeKjeder.genererMeldeperioderOgOppdaterKjeder(
     vedtaksliste: Rammevedtaksliste,
     clock: Clock,
 ): OppdaterteKjederOgMeldeperioder {
@@ -195,6 +195,13 @@ fun MeldeperiodeKjeder.finnNærmesteMeldeperiode(dato: LocalDate): Periode {
     return Periode(fraOgMed, fraOgMed.plusDays(13))
 }
 
+private fun MeldeperiodeKjeder.oppdaterEllerLeggTilNy(meldeperioder: List<Meldeperiode>): OppdaterteKjederOgMeldeperioder {
+    return meldeperioder.fold(this to listOf()) { acc, m ->
+        val ny = acc.first.oppdaterEllerLeggTilNy(m)
+        Pair(ny.first, listOfNotNull(ny.second).plus(acc.second).sorted())
+    }
+}
+
 /** Perioden må matche 1-1 med en eksisterende meldeperiode, hvis ikke legger den til en ny. */
 private fun MeldeperiodeKjeder.oppdaterEllerLeggTilNy(meldeperiode: Meldeperiode): Pair<MeldeperiodeKjeder, Meldeperiode?> {
     val kjede = hentMeldeperiodeKjedeForPeriode(meldeperiode.periode)
@@ -204,7 +211,7 @@ private fun MeldeperiodeKjeder.oppdaterEllerLeggTilNy(meldeperiode: Meldeperiode
                 this to null
             } else {
                 MeldeperiodeKjeder(
-                    (this.plus(listOf(MeldeperiodeKjede(nonEmptyListOf(meldeperiode))))).sorted(),
+                    this.plus(listOf(MeldeperiodeKjede(nonEmptyListOf(meldeperiode)))).sorted(),
                 ) to meldeperiode
             }
         }
@@ -220,11 +227,4 @@ private fun MeldeperiodeKjeder.oppdaterEllerLeggTilNy(meldeperiode: Meldeperiode
             }
         },
     ) to oppdatertMeldeperiode
-}
-
-private fun MeldeperiodeKjeder.oppdaterEllerLeggTilNy(meldeperioder: List<Meldeperiode>): Pair<MeldeperiodeKjeder, List<Meldeperiode>> {
-    return meldeperioder.fold(this to listOf()) { acc, m ->
-        val ny = acc.first.oppdaterEllerLeggTilNy(m)
-        Pair(ny.first, listOfNotNull(ny.second).plus(acc.second).sorted())
-    }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldeperiode/GenererMeldeperioderEx.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldeperiode/GenererMeldeperioderEx.kt
@@ -37,6 +37,31 @@ enum class GenererMeldeperioderFeil {
     UgyldigDato,
 }
 
+fun MeldeperiodeKjeder.genererMeldeperioderOgOppdaterKjeder(
+    vedtaksliste: Rammevedtaksliste,
+    clock: Clock,
+): Either<GenererMeldeperioderFeil, OppdaterteKjederOgMeldeperioder> {
+    if (vedtaksliste.isEmpty()) {
+        if (this.isNotEmpty()) {
+            return GenererMeldeperioderFeil.HarMeldeperioderUtenVedtaksperioder.left()
+        }
+        return (this to emptyList<Meldeperiode>()).right()
+    }
+
+    return this.genererMeldeperioder(
+        vedtaksperioder = vedtaksliste.vedtaksperioder,
+        hentAntallDager = { vedtaksliste.antallDagerForMeldeperiode(it) },
+        hentVedtakIder = { vedtaksliste.vedtakForPeriode(it) as IkkeTomPeriodisering },
+        harRett = { vedtaksliste.harInnvilgetTiltakspengerPåDato(it) },
+        fnr = vedtaksliste.fnr!!,
+        saksnummer = vedtaksliste.saksnummer!!,
+        sakId = vedtaksliste.sakId!!,
+        clock = clock,
+    ).map {
+        this.oppdaterEllerLeggTilNy(it)
+    }
+}
+
 /**
  *  Genererer hypotetiske meldeperioder ut fra en ikke-vedtatt behandling.
  *
@@ -98,31 +123,6 @@ fun Sak.genererMeldeperioderForValidering(
         sakId = id,
         clock = clock,
     )
-}
-
-fun MeldeperiodeKjeder.genererMeldeperioderOgOppdaterKjeder(
-    vedtaksliste: Rammevedtaksliste,
-    clock: Clock,
-): Either<GenererMeldeperioderFeil, OppdaterteKjederOgMeldeperioder> {
-    if (vedtaksliste.isEmpty()) {
-        if (this.isNotEmpty()) {
-            return GenererMeldeperioderFeil.HarMeldeperioderUtenVedtaksperioder.left()
-        }
-        return (this to emptyList<Meldeperiode>()).right()
-    }
-
-    return this.genererMeldeperioder(
-        vedtaksperioder = vedtaksliste.vedtaksperioder,
-        hentAntallDager = { vedtaksliste.antallDagerForMeldeperiode(it) },
-        hentVedtakIder = { vedtaksliste.vedtakForPeriode(it) as IkkeTomPeriodisering },
-        harRett = { vedtaksliste.harInnvilgetTiltakspengerPåDato(it) },
-        fnr = vedtaksliste.fnr!!,
-        saksnummer = vedtaksliste.saksnummer!!,
-        sakId = vedtaksliste.sakId!!,
-        clock = clock,
-    ).map {
-        this.oppdaterEllerLeggTilNy(it)
-    }
 }
 
 private fun MeldeperiodeKjeder.genererMeldeperioder(

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldeperiode/GenererMeldeperioderEx.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldeperiode/GenererMeldeperioderEx.kt
@@ -1,0 +1,231 @@
+package no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode
+
+import arrow.core.nonEmptyListOf
+import no.nav.tiltakspenger.libs.common.Fnr
+import no.nav.tiltakspenger.libs.common.HendelseVersjon
+import no.nav.tiltakspenger.libs.common.SakId
+import no.nav.tiltakspenger.libs.common.Saksnummer
+import no.nav.tiltakspenger.libs.common.VedtakId
+import no.nav.tiltakspenger.libs.periode.Periode
+import no.nav.tiltakspenger.libs.periode.leggSammen
+import no.nav.tiltakspenger.libs.periode.overlapper
+import no.nav.tiltakspenger.libs.periodisering.IkkeTomPeriodisering
+import no.nav.tiltakspenger.saksbehandling.behandling.domene.AntallDagerForMeldeperiode
+import no.nav.tiltakspenger.saksbehandling.behandling.domene.Rammebehandling
+import no.nav.tiltakspenger.saksbehandling.behandling.domene.Rammebehandlingsstatus
+import no.nav.tiltakspenger.saksbehandling.behandling.domene.finnAntallDagerForMeldeperiode
+import no.nav.tiltakspenger.saksbehandling.sak.Sak
+import no.nav.tiltakspenger.saksbehandling.vedtak.Rammevedtaksliste
+import java.time.Clock
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+import java.time.temporal.TemporalAdjusters
+import kotlin.collections.sorted
+import kotlin.math.min
+
+typealias OppdaterteKjederOgMeldeperioder = Pair<MeldeperiodeKjeder, List<Meldeperiode>>
+
+/**
+ *  Genererer hypotetiske meldeperioder ut fra en ikke-vedtatt behandling.
+ *
+ *  Skal kun benyttes for validering/testing, ikke for å generere faktiske meldeperioder som persisteres!
+ * */
+fun Sak.genererMeldeperioderForValidering(rammebehandling: Rammebehandling, clock: Clock): List<Meldeperiode> {
+    val vedtaksperiode = rammebehandling.vedtaksperiode
+
+    requireNotNull(vedtaksperiode) {
+        "Behandling må ha satt en vedtaksperiode for å generere meldeperioder"
+    }
+
+    require(rammebehandling.status != Rammebehandlingsstatus.VEDTATT) {
+        "For vedtatte behandlinger skal meldeperioder genereres kun ut fra vedtak på saken"
+    }
+
+    return this.meldeperiodeKjeder.genererMeldeperioder(
+        vedtaksperioder = rammevedtaksliste.vedtaksperioder
+            .plus(vedtaksperiode)
+            .leggSammen(true),
+        hentAntallDager = { periode ->
+            val antallDagerFraSak by lazy { rammevedtaksliste.antallDagerForMeldeperiode(periode) }
+            val antallDagerFraBehandling by lazy {
+                rammebehandling.antallDagerPerMeldeperiode?.finnAntallDagerForMeldeperiode(periode)
+            }
+
+            when {
+                // Meldeperioden er i sin helhet innenfor behandlingens vedtaksperiode -> bruk verdien fra behandlingen
+                vedtaksperiode.inneholderHele(periode) -> antallDagerFraBehandling
+
+                // Meldeperioden er i sin helhet utenfor behandlingens vedtaksperiode -> bruk verdien fra saken
+                !vedtaksperiode.overlapperMed(periode) -> antallDagerFraSak
+
+                // Delvis overlapp -> bruk den høyeste av verdiene fra saken og behandlingen
+                else -> listOfNotNull(antallDagerFraSak, antallDagerFraBehandling).maxOrNull()
+            }
+        },
+        hentVedtakIder = { periode ->
+            val vedtakIderFraSak = rammevedtaksliste.vedtakForPeriode(periode)
+            val overlappMedBehandling = periode.overlappendePeriode(vedtaksperiode)
+            if (overlappMedBehandling == null) {
+                // Meldeperioden er i sin helhet utenfor behandlingens vedtaksperiode -> bruk vedtakene fra saken
+                vedtakIderFraSak as IkkeTomPeriodisering
+            } else {
+                // Overskriver den delen som overlapper behandlingen med den nye (midlertidige) vedtakId-en,
+                // og beholder eventuelle vedtak fra saken for resten av perioden.
+                vedtakIderFraSak.setVerdiForDelperiode(VedtakId.random(), overlappMedBehandling)
+            }
+        },
+        harRett = { dato ->
+            if (vedtaksperiode.inneholder(dato)) {
+                rammebehandling.innvilgelsesperioder?.hentVerdiForDag(dato) != null
+            } else {
+                rammevedtaksliste.harInnvilgetTiltakspengerPåDato(dato)
+            }
+        },
+        fnr = fnr,
+        saksnummer = saksnummer,
+        sakId = id,
+        clock = clock,
+    )
+}
+
+fun MeldeperiodeKjeder.genererMeldeperioder(
+    vedtaksliste: Rammevedtaksliste,
+    clock: Clock,
+): OppdaterteKjederOgMeldeperioder {
+    if (vedtaksliste.isEmpty()) {
+        require(this.isEmpty()) { "Forventet ingen meldeperioder dersom det ikke er noen vedtaksperioder" }
+        return this to emptyList()
+    }
+
+    return this.genererMeldeperioder(
+        vedtaksperioder = vedtaksliste.vedtaksperioder,
+        hentAntallDager = { vedtaksliste.antallDagerForMeldeperiode(it) },
+        hentVedtakIder = { vedtaksliste.vedtakForPeriode(it) as IkkeTomPeriodisering },
+        harRett = { vedtaksliste.harInnvilgetTiltakspengerPåDato(it) },
+        fnr = vedtaksliste.fnr!!,
+        saksnummer = vedtaksliste.saksnummer!!,
+        sakId = vedtaksliste.sakId!!,
+        clock = clock,
+    ).let {
+        this.oppdaterEllerLeggTilNy(it)
+    }
+}
+
+private fun MeldeperiodeKjeder.genererMeldeperioder(
+    vedtaksperioder: List<Periode>,
+    hentAntallDager: (periode: Periode) -> AntallDagerForMeldeperiode?,
+    hentVedtakIder: (periode: Periode) -> IkkeTomPeriodisering<VedtakId>,
+    harRett: (dato: LocalDate) -> Boolean,
+    fnr: Fnr,
+    saksnummer: Saksnummer,
+    sakId: SakId,
+    clock: Clock,
+): List<Meldeperiode> {
+    return this
+        .genererPerioder(vedtaksperioder)
+        .map { periode ->
+            val girRett = periode
+                .tilDager()
+                .associateWith { harRett(it) }
+
+            // Antall dager som kan meldes kan ikke være høyere enn antall dager som gir rett
+            // Tar hensyn til meldeperioder som ikke overlapper 100% med innvilgelsesperiodene
+            val antallDagerFraTidslinje = girRett.count { it.value }
+            val antallDagerFraVedtak = hentAntallDager(periode)?.value ?: 0
+            val antallDagerForPeriode = min(antallDagerFraTidslinje, antallDagerFraVedtak)
+
+            val version = hentMeldeperiodeKjedeForPeriode(periode)?.nesteVersjon()
+                ?: HendelseVersjon.ny()
+
+            Meldeperiode.opprettMeldeperiode(
+                periode = periode,
+                girRett = girRett,
+                fnr = fnr,
+                saksnummer = saksnummer,
+                sakId = sakId,
+                antallDagerForPeriode = antallDagerForPeriode,
+                versjon = version,
+                rammevedtak = hentVedtakIder(periode),
+                clock = clock,
+            )
+        }
+}
+
+/**
+ * @return Alle 14-dagers perioder som overlapper med [vedtaksperioder]
+ *
+ * */
+private fun MeldeperiodeKjeder.genererPerioder(vedtaksperioder: List<Periode>): List<Periode> {
+    val totalPeriode = vedtaksperioder.let {
+        Periode(it.first().fraOgMed, it.last().tilOgMed)
+    }
+
+    val førstePeriode = finnNærmesteMeldeperiode(totalPeriode.fraOgMed)
+
+    return generateSequence(førstePeriode) { forrige ->
+        val nesteFraOgMed = forrige.tilOgMed.plusDays(1)
+        Periode(nesteFraOgMed, nesteFraOgMed.plusDays(13))
+    }
+        .takeWhile { it.fraOgMed <= totalPeriode.tilOgMed }
+        .filter { vedtaksperioder.overlapper(it) || harMeldeperiode(it) }
+        .toList()
+}
+
+/**
+ *  @return 14-dagers periode som inneholder [dato] og som er i fase med eksisterende meldeperioder på saken,
+ *  eller ny periode fra forrige mandag dersom det ikke finnes eksisterende meldeperioder
+ *
+ * */
+fun MeldeperiodeKjeder.finnNærmesteMeldeperiode(dato: LocalDate): Periode {
+    require(dato != LocalDate.MIN && dato != LocalDate.MAX) {
+        "Dato må være en gyldig dato, ikke MIN eller MAX"
+    }
+
+    val eksisterendeFraOgMed = this.firstOrNull()?.periode?.fraOgMed
+
+    if (eksisterendeFraOgMed == null) {
+        val førsteMandag = dato.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+        val sisteSøndag = førsteMandag.plusDays(13)
+        return Periode(førsteMandag, sisteSøndag)
+    }
+
+    val dagerFraFørstePeriode = ChronoUnit.DAYS.between(eksisterendeFraOgMed, dato)
+    val periodeForskyvning = Math.floorDiv(dagerFraFørstePeriode, 14L)
+    val fraOgMed = eksisterendeFraOgMed.plusDays(periodeForskyvning * 14)
+    return Periode(fraOgMed, fraOgMed.plusDays(13))
+}
+
+/** Perioden må matche 1-1 med en eksisterende meldeperiode, hvis ikke legger den til en ny. */
+private fun MeldeperiodeKjeder.oppdaterEllerLeggTilNy(meldeperiode: Meldeperiode): Pair<MeldeperiodeKjeder, Meldeperiode?> {
+    val kjede = hentMeldeperiodeKjedeForPeriode(meldeperiode.periode)
+        ?: return run {
+            if (meldeperiode.ingenDagerGirRett) {
+                // Det finnes ikke noen kjeder fra før, og meldeperioden gir heller ikke noen rett til de dagene. Så vi legger ikke til noe
+                this to null
+            } else {
+                MeldeperiodeKjeder(
+                    (this.plus(listOf(MeldeperiodeKjede(nonEmptyListOf(meldeperiode))))).sorted(),
+                ) to meldeperiode
+            }
+        }
+
+    val (oppdatertKjede, oppdatertMeldeperiode) = kjede.leggTilMeldeperiode(meldeperiode)
+
+    return MeldeperiodeKjeder(
+        this.map {
+            if (it.kjedeId == oppdatertKjede.kjedeId) {
+                oppdatertKjede
+            } else {
+                it
+            }
+        },
+    ) to oppdatertMeldeperiode
+}
+
+private fun MeldeperiodeKjeder.oppdaterEllerLeggTilNy(meldeperioder: List<Meldeperiode>): Pair<MeldeperiodeKjeder, List<Meldeperiode>> {
+    return meldeperioder.fold(this to listOf()) { acc, m ->
+        val ny = acc.first.oppdaterEllerLeggTilNy(m)
+        Pair(ny.first, listOfNotNull(ny.second).plus(acc.second).sorted())
+    }
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldeperiode/GenererMeldeperioderEx.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldeperiode/GenererMeldeperioderEx.kt
@@ -21,7 +21,6 @@ import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 import java.time.temporal.TemporalAdjusters
-import kotlin.collections.sorted
 import kotlin.math.min
 
 typealias OppdaterteKjederOgMeldeperioder = Pair<MeldeperiodeKjeder, List<Meldeperiode>>

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldeperiode/GenererMeldeperioderEx.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldeperiode/GenererMeldeperioderEx.kt
@@ -1,6 +1,9 @@
 package no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode
 
+import arrow.core.Either
+import arrow.core.left
 import arrow.core.nonEmptyListOf
+import arrow.core.right
 import no.nav.tiltakspenger.libs.common.Fnr
 import no.nav.tiltakspenger.libs.common.HendelseVersjon
 import no.nav.tiltakspenger.libs.common.SakId
@@ -25,20 +28,29 @@ import kotlin.math.min
 
 typealias OppdaterteKjederOgMeldeperioder = Pair<MeldeperiodeKjeder, List<Meldeperiode>>
 
+enum class GenererMeldeperioderFeil {
+    BehandlingManglerVedtaksperiode,
+    FeilKallForVedtattBehandling,
+    HarMeldeperioderUtenVedtaksperioder,
+
+    /** Den angitte datoen er ikke en gyldig dato (MIN eller MAX). */
+    UgyldigDato,
+}
+
 /**
  *  Genererer hypotetiske meldeperioder ut fra en ikke-vedtatt behandling.
  *
  *  Skal kun benyttes for validering/testing, ikke for å generere faktiske meldeperioder som persisteres
  * */
-fun Sak.genererMeldeperioderForValidering(rammebehandling: Rammebehandling, clock: Clock): List<Meldeperiode> {
+fun Sak.genererMeldeperioderForValidering(
+    rammebehandling: Rammebehandling,
+    clock: Clock,
+): Either<GenererMeldeperioderFeil, List<Meldeperiode>> {
     val vedtaksperiode = rammebehandling.vedtaksperiode
+        ?: return GenererMeldeperioderFeil.BehandlingManglerVedtaksperiode.left()
 
-    requireNotNull(vedtaksperiode) {
-        "Behandling må ha satt en vedtaksperiode for å generere meldeperioder"
-    }
-
-    require(rammebehandling.status != Rammebehandlingsstatus.VEDTATT) {
-        "For vedtatte behandlinger skal meldeperioder genereres kun ut fra vedtak på saken"
+    if (rammebehandling.status == Rammebehandlingsstatus.VEDTATT) {
+        return GenererMeldeperioderFeil.FeilKallForVedtattBehandling.left()
     }
 
     return this.meldeperiodeKjeder.genererMeldeperioder(
@@ -91,10 +103,12 @@ fun Sak.genererMeldeperioderForValidering(rammebehandling: Rammebehandling, cloc
 fun MeldeperiodeKjeder.genererMeldeperioderOgOppdaterKjeder(
     vedtaksliste: Rammevedtaksliste,
     clock: Clock,
-): OppdaterteKjederOgMeldeperioder {
+): Either<GenererMeldeperioderFeil, OppdaterteKjederOgMeldeperioder> {
     if (vedtaksliste.isEmpty()) {
-        require(this.isEmpty()) { "Forventet ingen meldeperioder dersom det ikke er noen vedtaksperioder" }
-        return this to emptyList()
+        if (this.isNotEmpty()) {
+            return GenererMeldeperioderFeil.HarMeldeperioderUtenVedtaksperioder.left()
+        }
+        return (this to emptyList<Meldeperiode>()).right()
     }
 
     return this.genererMeldeperioder(
@@ -106,7 +120,7 @@ fun MeldeperiodeKjeder.genererMeldeperioderOgOppdaterKjeder(
         saksnummer = vedtaksliste.saksnummer!!,
         sakId = vedtaksliste.sakId!!,
         clock = clock,
-    ).let {
+    ).map {
         this.oppdaterEllerLeggTilNy(it)
     }
 }
@@ -120,34 +134,36 @@ private fun MeldeperiodeKjeder.genererMeldeperioder(
     saksnummer: Saksnummer,
     sakId: SakId,
     clock: Clock,
-): List<Meldeperiode> {
+): Either<GenererMeldeperioderFeil, List<Meldeperiode>> {
     return this
         .genererPerioder(vedtaksperioder)
-        .map { periode ->
-            val girRett = periode
-                .tilDager()
-                .associateWith { harRett(it) }
+        .map { perioder ->
+            perioder.map { periode ->
+                val girRett = periode
+                    .tilDager()
+                    .associateWith { harRett(it) }
 
-            // Antall dager som kan meldes kan ikke være høyere enn antall dager som gir rett
-            // Tar hensyn til meldeperioder som ikke overlapper 100% med innvilgelsesperiodene
-            val antallDagerFraTidslinje = girRett.count { it.value }
-            val antallDagerFraVedtak = hentAntallDager(periode)?.value ?: 0
-            val antallDagerForPeriode = min(antallDagerFraTidslinje, antallDagerFraVedtak)
+                // Antall dager som kan meldes kan ikke være høyere enn antall dager som gir rett
+                // Tar hensyn til meldeperioder som ikke overlapper 100% med innvilgelsesperiodene
+                val antallDagerFraTidslinje = girRett.count { it.value }
+                val antallDagerFraVedtak = hentAntallDager(periode)?.value ?: 0
+                val antallDagerForPeriode = min(antallDagerFraTidslinje, antallDagerFraVedtak)
 
-            val meldeperiodeVersjon = hentMeldeperiodeKjedeForPeriode(periode)?.nesteVersjon()
-                ?: HendelseVersjon.ny()
+                val meldeperiodeVersjon = hentMeldeperiodeKjedeForPeriode(periode)?.nesteVersjon()
+                    ?: HendelseVersjon.ny()
 
-            Meldeperiode.opprettMeldeperiode(
-                periode = periode,
-                girRett = girRett,
-                fnr = fnr,
-                saksnummer = saksnummer,
-                sakId = sakId,
-                antallDagerForPeriode = antallDagerForPeriode,
-                versjon = meldeperiodeVersjon,
-                rammevedtak = hentVedtakIder(periode),
-                clock = clock,
-            )
+                Meldeperiode.opprettMeldeperiode(
+                    periode = periode,
+                    girRett = girRett,
+                    fnr = fnr,
+                    saksnummer = saksnummer,
+                    sakId = sakId,
+                    antallDagerForPeriode = antallDagerForPeriode,
+                    versjon = meldeperiodeVersjon,
+                    rammevedtak = hentVedtakIder(periode),
+                    clock = clock,
+                )
+            }
         }
 }
 
@@ -155,20 +171,22 @@ private fun MeldeperiodeKjeder.genererMeldeperioder(
  * @return Alle 14-dagers perioder som overlapper med [vedtaksperioder] eller eksisterende meldeperioder
  *
  * */
-private fun MeldeperiodeKjeder.genererPerioder(vedtaksperioder: List<Periode>): List<Periode> {
+private fun MeldeperiodeKjeder.genererPerioder(
+    vedtaksperioder: List<Periode>,
+): Either<GenererMeldeperioderFeil, List<Periode>> {
     val totalPeriode = vedtaksperioder.let {
         Periode(it.first().fraOgMed, it.last().tilOgMed)
     }
 
-    val førstePeriode = finnNærmesteMeldeperiode(totalPeriode.fraOgMed)
-
-    return generateSequence(førstePeriode) { forrige ->
-        val nesteFraOgMed = forrige.tilOgMed.plusDays(1)
-        Periode(nesteFraOgMed, nesteFraOgMed.plusDays(13))
+    return finnNærmesteMeldeperiode(totalPeriode.fraOgMed).map { førstePeriode ->
+        generateSequence(førstePeriode) { forrige ->
+            val nesteFraOgMed = forrige.tilOgMed.plusDays(1)
+            Periode(nesteFraOgMed, nesteFraOgMed.plusDays(13))
+        }
+            .takeWhile { it.fraOgMed <= totalPeriode.tilOgMed }
+            .filter { vedtaksperioder.overlapper(it) || harMeldeperiode(it) }
+            .toList()
     }
-        .takeWhile { it.fraOgMed <= totalPeriode.tilOgMed }
-        .filter { vedtaksperioder.overlapper(it) || harMeldeperiode(it) }
-        .toList()
 }
 
 /**
@@ -176,9 +194,9 @@ private fun MeldeperiodeKjeder.genererPerioder(vedtaksperioder: List<Periode>): 
  *  eller ny periode fra forrige mandag dersom det ikke finnes eksisterende meldeperioder
  *
  * */
-fun MeldeperiodeKjeder.finnNærmesteMeldeperiode(dato: LocalDate): Periode {
-    require(dato != LocalDate.MIN && dato != LocalDate.MAX) {
-        "Dato må være en gyldig dato, ikke MIN eller MAX"
+fun MeldeperiodeKjeder.finnNærmesteMeldeperiode(dato: LocalDate): Either<GenererMeldeperioderFeil, Periode> {
+    if (dato == LocalDate.MIN || dato == LocalDate.MAX) {
+        return GenererMeldeperioderFeil.UgyldigDato.left()
     }
 
     val eksisterendeFraOgMed = this.firstOrNull()?.periode?.fraOgMed
@@ -186,13 +204,13 @@ fun MeldeperiodeKjeder.finnNærmesteMeldeperiode(dato: LocalDate): Periode {
     if (eksisterendeFraOgMed == null) {
         val førsteMandag = dato.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
         val sisteSøndag = førsteMandag.plusDays(13)
-        return Periode(førsteMandag, sisteSøndag)
+        return Periode(førsteMandag, sisteSøndag).right()
     }
 
     val dagerFraFørstePeriode = ChronoUnit.DAYS.between(eksisterendeFraOgMed, dato)
     val periodeForskyvning = Math.floorDiv(dagerFraFørstePeriode, 14L)
     val fraOgMed = eksisterendeFraOgMed.plusDays(periodeForskyvning * 14)
-    return Periode(fraOgMed, fraOgMed.plusDays(13))
+    return Periode(fraOgMed, fraOgMed.plusDays(13)).right()
 }
 
 private fun MeldeperiodeKjeder.oppdaterEllerLeggTilNy(meldeperioder: List<Meldeperiode>): OppdaterteKjederOgMeldeperioder {

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldeperiode/GenererMeldeperioderEx.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldeperiode/GenererMeldeperioderEx.kt
@@ -153,7 +153,7 @@ private fun MeldeperiodeKjeder.genererMeldeperioder(
 }
 
 /**
- * @return Alle 14-dagers perioder som overlapper med [vedtaksperioder]
+ * @return Alle 14-dagers perioder som overlapper med [vedtaksperioder] eller eksisterende meldeperioder
  *
  * */
 private fun MeldeperiodeKjeder.genererPerioder(vedtaksperioder: List<Periode>): List<Periode> {

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldeperiode/MeldeperiodeKjeder.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldeperiode/MeldeperiodeKjeder.kt
@@ -1,25 +1,15 @@
 package no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode
 
-import arrow.core.nonEmptyListOf
 import arrow.core.toNonEmptyListOrNull
 import no.nav.tiltakspenger.libs.common.Fnr
-import no.nav.tiltakspenger.libs.common.HendelseVersjon
 import no.nav.tiltakspenger.libs.common.SakId
 import no.nav.tiltakspenger.libs.common.Saksnummer
 import no.nav.tiltakspenger.libs.common.nonDistinctBy
 import no.nav.tiltakspenger.libs.meldekort.MeldeperiodeId
 import no.nav.tiltakspenger.libs.meldekort.MeldeperiodeKjedeId
 import no.nav.tiltakspenger.libs.periode.Periode
-import no.nav.tiltakspenger.libs.periode.overlapperIkke
-import no.nav.tiltakspenger.libs.periodisering.IkkeTomPeriodisering
 import no.nav.tiltakspenger.saksbehandling.felles.singleOrNullOrThrow
-import no.nav.tiltakspenger.saksbehandling.vedtak.Rammevedtaksliste
-import java.time.Clock
-import java.time.DayOfWeek
-import java.time.LocalDate
 import java.time.temporal.ChronoUnit
-import java.time.temporal.TemporalAdjusters
-import kotlin.math.min
 
 data class MeldeperiodeKjeder(
     private val meldeperiodeKjeder: List<MeldeperiodeKjede>,
@@ -105,125 +95,6 @@ data class MeldeperiodeKjeder(
         return meldeperiode == meldeperiodeKjede.last()
     }
 
-    /** Perioden må matche 1-1 med en eksisterende meldeperiode, hvis ikke legger den til en ny. */
-    fun oppdaterEllerLeggTilNy(meldeperiode: Meldeperiode): Pair<MeldeperiodeKjeder, Meldeperiode?> {
-        val kjede = hentMeldeperiodeKjedeForPeriode(meldeperiode.periode)
-            ?: return run {
-                if (meldeperiode.ingenDagerGirRett) {
-                    // Det finnes ikke noen kjeder fra får, og meldeperioden gir heller ikke noen rett til de dagene. Så vi legger ikke til noe
-                    this to null
-                } else {
-                    MeldeperiodeKjeder(
-                        (this.meldeperiodeKjeder.plus(listOf(MeldeperiodeKjede(nonEmptyListOf(meldeperiode))))).sorted(),
-                    ) to meldeperiode
-                }
-            }
-
-        val (oppdatertKjede, oppdatertMeldeperiode) = kjede.leggTilMeldeperiode(meldeperiode)
-
-        return MeldeperiodeKjeder(
-            this.meldeperiodeKjeder.map {
-                if (it.kjedeId == oppdatertKjede.kjedeId) {
-                    oppdatertKjede
-                } else {
-                    it
-                }
-            },
-        ) to oppdatertMeldeperiode
-    }
-
-    fun oppdaterEllerLeggTilNy(meldeperioder: List<Meldeperiode>): Pair<MeldeperiodeKjeder, List<Meldeperiode>> =
-        meldeperioder.fold(this to listOf()) { acc, m ->
-            val ny = acc.first.oppdaterEllerLeggTilNy(m)
-            Pair(ny.first, listOfNotNull(ny.second).plus(acc.second).sorted())
-        }
-
-    fun genererMeldeperioder(
-        vedtaksliste: Rammevedtaksliste,
-        clock: Clock,
-    ): Pair<MeldeperiodeKjeder, List<Meldeperiode>> {
-        if (vedtaksliste.isEmpty()) {
-            require(this.isEmpty()) { "Forventet ingen meldeperioder ved tom vedtaksliste" }
-            return this to emptyList()
-        }
-        val vedtaksperioder = vedtaksliste.vedtaksperioder
-        val førsteFraOgMed = vedtaksperioder.first().fraOgMed
-        val sisteTilOgMed = vedtaksperioder.last().tilOgMed
-        var nærmesteMeldeperiode = finnNærmesteMeldeperiode(førsteFraOgMed)
-
-        val potensielleNyeMeldeperioder = mutableListOf<Meldeperiode>()
-
-        // før eller samme dag
-        while (!nærmesteMeldeperiode.starterEtter(sisteTilOgMed)) {
-            if (vedtaksperioder.overlapperIkke(nærmesteMeldeperiode) && !this.harMeldeperiode(nærmesteMeldeperiode)) {
-                // hvis perioden ikke overlapper, og den ikke finnes fra før, så skal ikke vi oppdatere noe
-                nærmesteMeldeperiode = nærmesteMeldeperiode.nesteMeldeperiode()
-                continue
-            }
-            val girRett = nærmesteMeldeperiode.tilDager()
-                .associateWith { vedtaksliste.harInnvilgetTiltakspengerPåDato(it) }
-            val antallDagerSomGirRettForNærmesteMeldeperiode = girRett.count { it.value }
-
-            val antallDagerForMeldeperiodeFraBehandling =
-                vedtaksliste.antallDagerForMeldeperiode(nærmesteMeldeperiode)?.value ?: 0
-            val antallDagerSomGirRettForMeldePeriode =
-                min(antallDagerSomGirRettForNærmesteMeldeperiode, antallDagerForMeldeperiodeFraBehandling)
-
-            val kjede = this.hentMeldeperiodeKjedeForPeriode(nærmesteMeldeperiode)
-            val versjon = kjede?.nesteVersjon() ?: HendelseVersjon.ny()
-            // Hvis den er lik den forrige meldeperioden, blir den ikke lagt til
-
-            val potensiellNyMeldeperiode = Meldeperiode.opprettMeldeperiode(
-                periode = nærmesteMeldeperiode,
-                girRett = girRett,
-                fnr = vedtaksliste.fnr!!,
-                saksnummer = vedtaksliste.saksnummer!!,
-                sakId = vedtaksliste.sakId!!,
-                antallDagerForPeriode = antallDagerSomGirRettForMeldePeriode,
-                versjon = versjon,
-                rammevedtak = vedtaksliste.vedtakForPeriode(nærmesteMeldeperiode) as IkkeTomPeriodisering,
-                clock = clock,
-            )
-
-            potensielleNyeMeldeperioder.add(potensiellNyMeldeperiode)
-            nærmesteMeldeperiode = nærmesteMeldeperiode.nesteMeldeperiode()
-        }
-
-        return this.oppdaterEllerLeggTilNy(potensielleNyeMeldeperioder)
-    }
-
-    /** Kun public for testing. Finner første meldeperiode med [dato] */
-    fun finnNærmesteMeldeperiode(dato: LocalDate): Periode {
-        require(dato != LocalDate.MIN && dato != LocalDate.MAX) { "Dato må være en gyldig dato, ikke MIN eller MAX" }
-        if (this.isEmpty()) return Companion.finnNærmesteMeldeperiode(dato)
-
-        val førstePeriode = this.meldeperiodeKjeder.first().periode
-
-        if (dato.isBefore(førstePeriode.fraOgMed)) {
-            var periode = førstePeriode
-            while (true) {
-                periode = periode.forrigeMeldeperiode()
-                if (periode.inneholder(dato)) {
-                    return periode
-                }
-            }
-        } else if (dato.isAfter(førstePeriode.tilOgMed)) {
-            var periode = førstePeriode
-            while (true) {
-                periode = periode.nesteMeldeperiode()
-                if (periode.inneholder(dato)) {
-                    return periode
-                }
-            }
-        }
-
-        return førstePeriode
-    }
-
-    fun hentMeldeperiodekjedeForKjedeId(kjedeId: MeldeperiodeKjedeId): MeldeperiodeKjede? {
-        return meldeperiodeKjeder.singleOrNullOrThrow { it.kjedeId == kjedeId }
-    }
-
     fun hentForegåendeMeldeperiodekjede(kjedeId: MeldeperiodeKjedeId): MeldeperiodeKjede? {
         return meldeperiodeKjeder.hentForegående(kjedeId)
     }
@@ -237,14 +108,6 @@ data class MeldeperiodeKjeder(
     }
 
     companion object {
-        /**
-         * Skal kun kalles/brukes på en sak som aldri har hatt en meldeperiode før
-         */
-        fun finnNærmesteMeldeperiode(dato: LocalDate): Periode {
-            val førsteMandagIMeldekortsperiode = dato.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
-            val sisteSøndagIMeldekortsperiode = førsteMandagIMeldekortsperiode.plusDays(13)
-            return Periode(førsteMandagIMeldekortsperiode, sisteSøndagIMeldekortsperiode)
-        }
 
         fun fraMeldeperioder(meldeperioder: List<Meldeperiode>): MeldeperiodeKjeder {
             return meldeperioder
@@ -260,16 +123,6 @@ data class MeldeperiodeKjeder(
         }
     }
 }
-
-fun Periode.forrigeMeldeperiode(): Periode = Periode(
-    this.fraOgMed.minusDays(14),
-    this.tilOgMed.minusDays(14),
-)
-
-fun Periode.nesteMeldeperiode(): Periode = Periode(
-    this.fraOgMed.plusDays(14),
-    this.tilOgMed.plusDays(14),
-)
 
 private fun List<MeldeperiodeKjede>.hentForegående(kjedeId: MeldeperiodeKjedeId): MeldeperiodeKjede? {
     this.zipWithNext { a, b -> if (b.kjedeId == kjedeId) return a }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldeperiode/ValiderMeldeperioderHelgEx.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldeperiode/ValiderMeldeperioderHelgEx.kt
@@ -1,10 +1,8 @@
-package no.nav.tiltakspenger.saksbehandling.behandling.domene
+package no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode
 
 import no.nav.tiltakspenger.libs.common.RammebehandlingId
 import no.nav.tiltakspenger.libs.meldekort.MeldeperiodeKjedeId
 import no.nav.tiltakspenger.saksbehandling.felles.erHverdag
-import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.Meldeperiode
-import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.genererMeldeperioderForValidering
 import no.nav.tiltakspenger.saksbehandling.sak.Sak
 import java.time.Clock
 
@@ -15,7 +13,7 @@ fun Sak.harGyldigeMeldeperioderForHelg(behandlingId: RammebehandlingId, clock: C
 
     val rammebehandling = hentRammebehandling(behandlingId)!!
 
-    // Uten en vedtaksperiode (f.eks. når resultatet er "ikke valgt") finnes det ingen meldeperioder å validere.
+    // Uten en vedtaksperiode (f.eks. når resultatet er "ikke valgt") finnes det ingen nye meldeperioder å validere.
     if (rammebehandling.vedtaksperiode == null) {
         return harGyldigeMeldeperioderForHelg()
     }
@@ -31,7 +29,9 @@ fun Sak.harGyldigeMeldeperioderForHelg(): Boolean {
 }
 
 fun Sak.hentMeldeperiodeKjederMedKunRettIHelg(): List<MeldeperiodeKjedeId> {
-    return this.meldeperiodeKjeder.sisteMeldeperiodePerKjede.hentMeldeperiodeKjederMedKunRettIHelg()
+    return this.meldeperiodeKjeder
+        .sisteMeldeperiodePerKjede
+        .hentMeldeperiodeKjederMedKunRettIHelg()
 }
 
 private fun List<Meldeperiode>.hentMeldeperiodeKjederMedKunRettIHelg(): List<MeldeperiodeKjedeId> {

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldeperiode/ValiderMeldeperioderHelgEx.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldeperiode/ValiderMeldeperioderHelgEx.kt
@@ -1,12 +1,13 @@
 package no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode
 
+import arrow.core.getOrElse
 import no.nav.tiltakspenger.libs.common.RammebehandlingId
 import no.nav.tiltakspenger.libs.meldekort.MeldeperiodeKjedeId
 import no.nav.tiltakspenger.saksbehandling.felles.erHverdag
 import no.nav.tiltakspenger.saksbehandling.sak.Sak
 import java.time.Clock
 
-fun Sak.harGyldigeMeldeperioderForHelg(behandlingId: RammebehandlingId, clock: Clock): Boolean {
+fun Sak.meldeperioderErGyldigeForHelg(behandlingId: RammebehandlingId, clock: Clock): Boolean {
     if (kanSendeInnHelgForMeldekort) {
         return true
     }
@@ -15,14 +16,15 @@ fun Sak.harGyldigeMeldeperioderForHelg(behandlingId: RammebehandlingId, clock: C
 
     // Uten en vedtaksperiode (f.eks. når resultatet er "ikke valgt") finnes det ingen nye meldeperioder å validere.
     if (rammebehandling.vedtaksperiode == null) {
-        return harGyldigeMeldeperioderForHelg()
+        return meldeperioderErGyldigeForHelg()
     }
 
     return genererMeldeperioderForValidering(rammebehandling, clock)
+        .getOrElse { throw IllegalStateException("Kunne ikke generere meldeperioder for validering på sak ${this.id}: $it") }
         .hentMeldeperiodeKjederMedKunRettIHelg().isEmpty()
 }
 
-fun Sak.harGyldigeMeldeperioderForHelg(): Boolean {
+fun Sak.meldeperioderErGyldigeForHelg(): Boolean {
     return kanSendeInnHelgForMeldekort || meldeperiodeKjeder
         .sisteMeldeperiodePerKjede
         .hentMeldeperiodeKjederMedKunRettIHelg().isEmpty()

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/sak/Sak.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/sak/Sak.kt
@@ -30,6 +30,7 @@ import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortvedtak.Meld
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortvedtak.Meldekortvedtaksliste
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.Meldeperiode
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.MeldeperiodeKjeder
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.genererMeldeperioder
 import no.nav.tiltakspenger.saksbehandling.søknad.domene.Søknad
 import no.nav.tiltakspenger.saksbehandling.tilbakekreving.domene.TilbakekrevingBehandling
 import no.nav.tiltakspenger.saksbehandling.utbetaling.domene.Utbetalinger

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/sak/Sak.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/sak/Sak.kt
@@ -1,5 +1,6 @@
 package no.nav.tiltakspenger.saksbehandling.sak
 
+import arrow.core.getOrElse
 import no.nav.tiltakspenger.libs.common.Fnr
 import no.nav.tiltakspenger.libs.common.MeldekortId
 import no.nav.tiltakspenger.libs.common.RammebehandlingId
@@ -8,7 +9,6 @@ import no.nav.tiltakspenger.libs.common.Saksnummer
 import no.nav.tiltakspenger.libs.common.VedtakId
 import no.nav.tiltakspenger.libs.meldekort.MeldeperiodeKjedeId
 import no.nav.tiltakspenger.libs.periodisering.Periodisering
-import no.nav.tiltakspenger.libs.tiltak.TiltakstypeSomGirRett
 import no.nav.tiltakspenger.saksbehandling.barnetillegg.AntallBarn
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.Behandlinger
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.Rammebehandling
@@ -78,8 +78,6 @@ data class Sak(
     val revurderinger = rammebehandlinger.revurderinger
 
     val barnetilleggsperioder: Periodisering<AntallBarn> by lazy { rammevedtaksliste.barnetilleggsperioder }
-
-    val tiltakstypeperioder: Periodisering<TiltakstypeSomGirRett> by lazy { rammevedtaksliste.tiltakstypeperioder }
 
     /** Et førstegangsvedtak defineres som den første søknadsbehandlingen som førte til innvilgelse. */
     val harFørstegangsvedtak: Boolean by lazy { this.vedtaksliste.harFørstegangsvedtak }
@@ -181,6 +179,7 @@ data class Sak(
     fun genererMeldeperioder(clock: Clock): Pair<Sak, List<Meldeperiode>> {
         return this.meldeperiodeKjeder
             .genererMeldeperioderOgOppdaterKjeder(this.rammevedtaksliste, clock)
+            .getOrElse { throw IllegalStateException("Kunne ikke generere meldeperioder for sak ${this.id}: $it") }
             .let { this.copy(meldeperiodeKjeder = it.first) to it.second }
     }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/sak/Sak.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/sak/Sak.kt
@@ -30,7 +30,7 @@ import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortvedtak.Meld
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortvedtak.Meldekortvedtaksliste
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.Meldeperiode
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.MeldeperiodeKjeder
-import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.genererMeldeperioder
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.genererMeldeperioderOgOppdaterKjeder
 import no.nav.tiltakspenger.saksbehandling.søknad.domene.Søknad
 import no.nav.tiltakspenger.saksbehandling.tilbakekreving.domene.TilbakekrevingBehandling
 import no.nav.tiltakspenger.saksbehandling.utbetaling.domene.Utbetalinger
@@ -180,7 +180,7 @@ data class Sak(
 
     fun genererMeldeperioder(clock: Clock): Pair<Sak, List<Meldeperiode>> {
         return this.meldeperiodeKjeder
-            .genererMeldeperioder(this.rammevedtaksliste, clock)
+            .genererMeldeperioderOgOppdaterKjeder(this.rammevedtaksliste, clock)
             .let { this.copy(meldeperiodeKjeder = it.first) to it.second }
     }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/sak/infra/routes/ToggleKanSendeHelgForMeldekortSakRoute.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/sak/infra/routes/ToggleKanSendeHelgForMeldekortSakRoute.kt
@@ -1,9 +1,11 @@
 package no.nav.tiltakspenger.saksbehandling.sak.infra.routes
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.http.HttpStatusCode
 import io.ktor.server.auth.principal
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.post
+import no.nav.tiltakspenger.libs.ktor.common.ErrorJson
 import no.nav.tiltakspenger.libs.ktor.common.respondJson
 import no.nav.tiltakspenger.libs.ktor.common.withBody
 import no.nav.tiltakspenger.libs.ktor.common.withSakId
@@ -12,6 +14,7 @@ import no.nav.tiltakspenger.libs.texas.saksbehandler
 import no.nav.tiltakspenger.saksbehandling.auditlog.AuditLogEvent
 import no.nav.tiltakspenger.saksbehandling.auditlog.AuditService
 import no.nav.tiltakspenger.saksbehandling.auth.tilgangskontroll.TilgangskontrollService
+import no.nav.tiltakspenger.saksbehandling.behandling.service.sak.KunneIkkeOppdatereHelgForMeldekort
 import no.nav.tiltakspenger.saksbehandling.behandling.service.sak.SakService
 import no.nav.tiltakspenger.saksbehandling.felles.autoriserteBrukerroller
 import no.nav.tiltakspenger.saksbehandling.felles.krevSaksbehandlerEllerBeslutterRolle
@@ -51,8 +54,18 @@ fun Route.toggleKanSendeHelgForMeldekortSakRoute(
                     sakId = sakId,
                     kanSendeHelg = body.kanSendeHelg,
                 )
-                    .also { sak ->
+                    .onRight { sak ->
                         call.respondJson(value = sak.toSakDTO(saksbehandler, clock))
+                    }
+                    .onLeft {
+                        when (it) {
+                            is KunneIkkeOppdatereHelgForMeldekort.HarMeldeperioderMedKunHelg -> call.respondJson(
+                                HttpStatusCode.Conflict to ErrorJson(
+                                    melding = "Kan ikke slå av melding i helg - brukeren har meldeperioder med rett kun på helgedager: ${it.kjedeIder}",
+                                    kode = "kan_ikke_slå_av_helg",
+                                ),
+                            )
+                        }
                     }
             }
         }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tilbakekreving/infra/kafka/dto/TilbakekrevingInfoSvarDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/tilbakekreving/infra/kafka/dto/TilbakekrevingInfoSvarDTO.kt
@@ -21,7 +21,6 @@ data class TilbakekrevingInfoSvarDTO(
     }
 
     data class TilbakekrevingMottaker(
-        // Vet ikke hvilke verdier denne kan ha ennå, så setter den til String inntil videre
         val type: TilbakekrevingMottakerType = TilbakekrevingMottakerType.PERSON,
         val ident: String,
     )

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/infra/route/iverksett/IverksettRevurderingTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/infra/route/iverksett/IverksettRevurderingTest.kt
@@ -1,16 +1,22 @@
 package no.nav.tiltakspenger.saksbehandling.behandling.infra.route.iverksett
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.ktor.http.HttpStatusCode
+import no.nav.tiltakspenger.libs.common.CorrelationId
 import no.nav.tiltakspenger.libs.common.TikkendeKlokke
+import no.nav.tiltakspenger.libs.common.nå
 import no.nav.tiltakspenger.libs.dato.april
 import no.nav.tiltakspenger.libs.dato.januar
+import no.nav.tiltakspenger.libs.dato.juni
 import no.nav.tiltakspenger.libs.dato.mars
 import no.nav.tiltakspenger.libs.periode.til
 import no.nav.tiltakspenger.saksbehandling.barnetillegg.AntallBarn
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.HjemmelForStans
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.Revurdering
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.Søknadsbehandling
+import no.nav.tiltakspenger.saksbehandling.behandling.service.behandling.IverksettRammebehandlingService
 import no.nav.tiltakspenger.saksbehandling.common.withTestApplicationContext
 import no.nav.tiltakspenger.saksbehandling.felles.Begrunnelse
 import no.nav.tiltakspenger.saksbehandling.fixedClockAt
@@ -416,6 +422,63 @@ internal class IverksettRevurderingTest {
                     }
                 """.trimIndent(),
             )
+        }
+    }
+
+    @Test
+    fun `Kan ikke iverksette rammevedtak dersom det ikke er det nyeste på saken`() {
+        val søknadsbehandlingPeriode = 1.til(10.april(2025))
+        val revurderingPeriode = 1.til(10.juni(2025))
+        withTestApplicationContext { tac ->
+            val (sak, _, rammevedtakSøknadsbehandling, revurdering) = iverksettSøknadsbehandlingOgStartRevurderingInnvilgelse(
+                tac,
+                søknadsbehandlingInnvilgelsesperioder = innvilgelsesperioder(søknadsbehandlingPeriode),
+                oppdatertTiltaksdeltakelse = tiltaksdeltakelse(revurderingPeriode),
+            )
+
+            oppdaterRevurderingInnvilgelse(
+                tac = tac,
+                sakId = sak.id,
+                behandlingId = revurdering.id,
+                fritekstTilVedtaksbrev = "brevtekst",
+                begrunnelseVilkårsvurdering = "begrunnelse",
+                innvilgelsesperioder = innvilgelsesperioder(revurderingPeriode),
+            )
+
+            sendRevurderingTilBeslutningForBehandlingId(tac, sak.id, revurdering.id)
+            taBehandling(tac, sak.id, revurdering.id, saksbehandler = ObjectMother.beslutter())
+
+            // Klokke satt før søknadsbehandlingsvedtaket sitt opprettet-tidspunkt, slik at det nye
+            // revurderingsvedtaket ikke ville blitt det «siste» vedtaket dersom listen ble sortert på opprettet.
+            val klokkeFørSøknadsbehandlingsvedtaket = fixedClockAt(1.april(2025))
+            val søknadsvedtakOpprettet = rammevedtakSøknadsbehandling.opprettet
+            require(nå(klokkeFørSøknadsbehandlingsvedtaket).isBefore(søknadsvedtakOpprettet)) {
+                "Forutsetter at den tidligere klokken er før søknadsbehandlingsvedtaket sitt opprettet-tidspunkt"
+            }
+
+            val iverksettServiceMedTidligereKlokke = IverksettRammebehandlingService(
+                rammebehandlingRepo = tac.behandlingContext.rammebehandlingRepo,
+                rammevedtakRepo = tac.behandlingContext.rammevedtakRepo,
+                meldekortbehandlingRepo = tac.meldekortContext.meldekortbehandlingRepo,
+                meldeperiodeRepo = tac.meldekortContext.meldeperiodeRepo,
+                sessionFactory = tac.sessionFactory,
+                sakService = tac.sakContext.sakService,
+                clock = klokkeFørSøknadsbehandlingsvedtaket,
+                oppdaterBeregningOgSimuleringService = tac.behandlingContext.oppdaterBeregningOgSimuleringService,
+                statistikkService = tac.statistikkContext.statistikkService,
+            )
+
+            // Vi når aldri guarden for VedtakErIkkeSisteVedtakPåSaken.
+            // Rammevedtaksliste-init validerer rekkefølgen på opprettet-tidspunkt først.
+            val exception = shouldThrow<IllegalArgumentException> {
+                iverksettServiceMedTidligereKlokke.iverksettRammebehandling(
+                    rammebehandlingId = revurdering.id,
+                    beslutter = ObjectMother.beslutter(),
+                    sakId = sak.id,
+                    correlationId = CorrelationId.generate(),
+                )
+            }
+            exception.message shouldContain "Vedtakene må være sortert på opprettet-tidspunkt"
         }
     }
 

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/infra/route/tilbeslutter/SendRevurderingTilBeslutningTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/infra/route/tilbeslutter/SendRevurderingTilBeslutningTest.kt
@@ -6,6 +6,7 @@ import io.ktor.http.HttpStatusCode
 import no.nav.tiltakspenger.libs.common.CorrelationId
 import no.nav.tiltakspenger.libs.common.RammebehandlingId
 import no.nav.tiltakspenger.libs.dato.april
+import no.nav.tiltakspenger.libs.dato.januar
 import no.nav.tiltakspenger.libs.periode.til
 import no.nav.tiltakspenger.saksbehandling.barnetillegg.Barnetillegg
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.AntallDagerForMeldeperiode
@@ -42,7 +43,11 @@ class SendRevurderingTilBeslutningTest {
     @Test
     fun `kan sende revurdering stans til beslutning`() {
         withTestApplicationContext { tac ->
-            val (sak, _, _, revurdering) = iverksettSøknadsbehandlingOgStartRevurderingStans(tac)
+            // Innvilgelsen starter mandag 2. januar 2023, slik at dagen som beholder rett etter stans (mandag) er en hverdag.
+            val (sak, _, _, revurdering) = iverksettSøknadsbehandlingOgStartRevurderingStans(
+                tac,
+                innvilgelsesperioder = innvilgelsesperioder(2 til 31.januar(2023)),
+            )
 
             val stansFraOgMed = sak.førsteDagSomGirRett!!.plusDays(1)
 
@@ -65,6 +70,64 @@ class SendRevurderingTilBeslutningTest {
             )
 
             JSONObject(responseBody).getString("status") shouldBe RammebehandlingsstatusDTO.KLAR_TIL_BESLUTNING.name
+        }
+    }
+
+    @Test
+    fun `kan sende revurdering stans til beslutning når meldeperiode kun har rett i helg men sak kan sende inn helg`() {
+        withTestApplicationContext { tac ->
+            // Default innvilgelse starter søndag 1. januar 2023. Stans fra dagen etter gjør at kun søndagen beholder rett,
+            // dvs. en meldeperiode med rett kun i helg. Det er likevel gyldig når saken kan sende inn helg.
+            val (sak, _, _, revurdering) = iverksettSøknadsbehandlingOgStartRevurderingStans(tac)
+
+            tac.sakContext.sakRepo.oppdaterKanSendeInnHelgForMeldekort(sak.id, true)
+
+            val stansFraOgMed = sak.førsteDagSomGirRett!!.plusDays(1)
+
+            oppdaterRevurderingStans(
+                tac = tac,
+                sakId = sak.id,
+                behandlingId = revurdering.id,
+                begrunnelseVilkårsvurdering = null,
+                fritekstTilVedtaksbrev = null,
+                valgteHjemler = setOf(HjemmelForStans.Alder),
+                stansFraOgMed = stansFraOgMed,
+                harValgtStansFraFørsteDagSomGirRett = false,
+            )
+
+            val responseBody = sendRevurderingTilBeslutningForBehandlingId(
+                tac = tac,
+                sakId = sak.id,
+                behandlingId = revurdering.id,
+                forventetStatus = HttpStatusCode.OK,
+            )
+
+            JSONObject(responseBody).getString("status") shouldBe RammebehandlingsstatusDTO.KLAR_TIL_BESLUTNING.name
+        }
+    }
+
+    @Test
+    fun `kan ikke oppdatere revurdering stans når meldeperiode kun har rett i helg`() {
+        withTestApplicationContext { tac ->
+            // Default innvilgelse starter søndag 1. januar 2023. Stans fra dagen etter gjør at kun søndagen beholder rett,
+            // dvs. en meldeperiode med rett kun i helg. Saken kan ikke sende inn helg, så oppdateringen skal avvises.
+            val (sak, _, _, revurdering) = iverksettSøknadsbehandlingOgStartRevurderingStans(tac)
+
+            val stansFraOgMed = sak.førsteDagSomGirRett!!.plusDays(1)
+
+            val (_, _, responseBody) = oppdaterRevurderingStans(
+                tac = tac,
+                sakId = sak.id,
+                behandlingId = revurdering.id,
+                begrunnelseVilkårsvurdering = null,
+                fritekstTilVedtaksbrev = null,
+                valgteHjemler = setOf(HjemmelForStans.Alder),
+                stansFraOgMed = stansFraOgMed,
+                harValgtStansFraFørsteDagSomGirRett = false,
+                forventetStatus = HttpStatusCode.Conflict,
+            )
+
+            responseBody harKode "ugyldige_meldeperioder_for_helg"
         }
     }
 

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldeperiodeKjederTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldeperiodeKjederTest.kt
@@ -21,7 +21,7 @@ import no.nav.tiltakspenger.libs.periode.til
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.MeldeperiodeKjede
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.MeldeperiodeKjeder
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.finnNærmesteMeldeperiode
-import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.genererMeldeperioder
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.genererMeldeperioderOgOppdaterKjeder
 import no.nav.tiltakspenger.saksbehandling.objectmothers.ObjectMother
 import no.nav.tiltakspenger.saksbehandling.objectmothers.ObjectMother.innvilgelsesperiodeKommando
 import no.nav.tiltakspenger.saksbehandling.omgjøring.OmgjortAvRammevedtak
@@ -119,7 +119,7 @@ class MeldeperiodeKjederTest {
                 innvilgelsesperiodeKommando(innvilgelsesperiode = periode),
             ),
         )
-        val actual = kjeder.genererMeldeperioder(
+        val actual = kjeder.genererMeldeperioderOgOppdaterKjeder(
             Rammevedtaksliste(
                 innvilgelseVedtak,
             ),
@@ -186,7 +186,7 @@ class MeldeperiodeKjederTest {
 
         val kjeder = MeldeperiodeKjeder(emptyList())
 
-        val actual = kjeder.genererMeldeperioder(vedtaksliste, fixedClock)
+        val actual = kjeder.genererMeldeperioderOgOppdaterKjeder(vedtaksliste, fixedClock)
 
         actual.let {
             it.first.size shouldBe 0
@@ -215,7 +215,7 @@ class MeldeperiodeKjederTest {
         val forventetFørstePeriode = Periode(2.januar(2023), 15.januar(2023))
         val forventetSistePeriode = Periode(16.januar(2023), 29.januar(2023))
 
-        val (nyeKjederV1) = kjederV1.genererMeldeperioder(v1, fixedClock).also {
+        val (nyeKjederV1) = kjederV1.genererMeldeperioderOgOppdaterKjeder(v1, fixedClock).also {
             it.first.sisteMeldeperiodePerKjede.size shouldBe 2
             it.first.sisteMeldeperiodePerKjede shouldBe it.second
 
@@ -259,7 +259,7 @@ class MeldeperiodeKjederTest {
             ),
         )
 
-        val actual = nyeKjederV1.genererMeldeperioder(v2, enUkeEtterFixedClock)
+        val actual = nyeKjederV1.genererMeldeperioderOgOppdaterKjeder(v2, enUkeEtterFixedClock)
 
         actual.let {
             it.first.sisteMeldeperiodePerKjede.size shouldBe 2
@@ -349,7 +349,7 @@ class MeldeperiodeKjederTest {
                 ),
             ),
         )
-        val actual = kjeder.genererMeldeperioder(
+        val actual = kjeder.genererMeldeperioderOgOppdaterKjeder(
             Rammevedtaksliste(
                 innvilgelseVedtak,
             ),

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldeperiodeKjederTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldeperiodeKjederTest.kt
@@ -20,6 +20,8 @@ import no.nav.tiltakspenger.libs.periode.Periode
 import no.nav.tiltakspenger.libs.periode.til
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.MeldeperiodeKjede
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.MeldeperiodeKjeder
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.finnNærmesteMeldeperiode
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.genererMeldeperioder
 import no.nav.tiltakspenger.saksbehandling.objectmothers.ObjectMother
 import no.nav.tiltakspenger.saksbehandling.objectmothers.ObjectMother.innvilgelsesperiodeKommando
 import no.nav.tiltakspenger.saksbehandling.omgjøring.OmgjortAvRammevedtak
@@ -36,8 +38,17 @@ class MeldeperiodeKjederTest {
     inner class FinnNærmesteMeldeperiodeForDato {
         @Test
         fun `tom kjede finner start dato for en kjede`() {
-            val kjeder = MeldeperiodeKjeder(emptyList())
-            kjeder.finnNærmesteMeldeperiode(2.januar(2023)) shouldBe Periode(2.januar(2023), 15.januar(2023))
+            val tommeKjeder = MeldeperiodeKjeder(emptyList())
+            tommeKjeder.finnNærmesteMeldeperiode(2.januar(2023)) shouldBe Periode(2.januar(2023), 15.januar(2023))
+            tommeKjeder.finnNærmesteMeldeperiode(7.april(2024)) shouldBe Periode(1.april(2024), 14.april(2024))
+            tommeKjeder.finnNærmesteMeldeperiode(8.april(2024)) shouldBe Periode(8.april(2024), 21.april(2024))
+            tommeKjeder.finnNærmesteMeldeperiode(9.april(2024)) shouldBe Periode(8.april(2024), 21.april(2024))
+            tommeKjeder.finnNærmesteMeldeperiode(10.april(2024)) shouldBe Periode(8.april(2024), 21.april(2024))
+            tommeKjeder.finnNærmesteMeldeperiode(11.april(2024)) shouldBe Periode(8.april(2024), 21.april(2024))
+            tommeKjeder.finnNærmesteMeldeperiode(12.april(2024)) shouldBe Periode(8.april(2024), 21.april(2024))
+            tommeKjeder.finnNærmesteMeldeperiode(13.april(2024)) shouldBe Periode(8.april(2024), 21.april(2024))
+            tommeKjeder.finnNærmesteMeldeperiode(14.april(2024)) shouldBe Periode(8.april(2024), 21.april(2024))
+            tommeKjeder.finnNærmesteMeldeperiode(15.april(2024)) shouldBe Periode(15.april(2024), 28.april(2024))
         }
 
         @Test
@@ -94,21 +105,6 @@ class MeldeperiodeKjederTest {
             )
             kjeder.finnNærmesteMeldeperiode(6.januar(2025)) shouldBe Periode(6.januar(2025), 19.januar(2025))
             kjeder.finnNærmesteMeldeperiode(19.januar(2025)) shouldBe Periode(6.januar(2025), 19.januar(2025))
-        }
-
-        @Test
-        fun `starten av en kjede for en sak`() {
-            MeldeperiodeKjeder.finnNærmesteMeldeperiode(7.april(2024)) shouldBe Periode(1.april(2024), 14.april(2024))
-
-            MeldeperiodeKjeder.finnNærmesteMeldeperiode(8.april(2024)) shouldBe Periode(8.april(2024), 21.april(2024))
-            MeldeperiodeKjeder.finnNærmesteMeldeperiode(9.april(2024)) shouldBe Periode(8.april(2024), 21.april(2024))
-            MeldeperiodeKjeder.finnNærmesteMeldeperiode(10.april(2024)) shouldBe Periode(8.april(2024), 21.april(2024))
-            MeldeperiodeKjeder.finnNærmesteMeldeperiode(11.april(2024)) shouldBe Periode(8.april(2024), 21.april(2024))
-            MeldeperiodeKjeder.finnNærmesteMeldeperiode(12.april(2024)) shouldBe Periode(8.april(2024), 21.april(2024))
-            MeldeperiodeKjeder.finnNærmesteMeldeperiode(13.april(2024)) shouldBe Periode(8.april(2024), 21.april(2024))
-            MeldeperiodeKjeder.finnNærmesteMeldeperiode(14.april(2024)) shouldBe Periode(8.april(2024), 21.april(2024))
-
-            MeldeperiodeKjeder.finnNærmesteMeldeperiode(15.april(2024)) shouldBe Periode(15.april(2024), 28.april(2024))
         }
     }
 

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldeperiodeKjederTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldeperiodeKjederTest.kt
@@ -1,5 +1,7 @@
 package no.nav.tiltakspenger.saksbehandling.meldekort.domene
 
+import arrow.core.left
+import arrow.core.right
 import io.kotest.matchers.shouldBe
 import no.nav.tiltakspenger.libs.common.Fnr
 import no.nav.tiltakspenger.libs.common.HendelseVersjon
@@ -18,6 +20,7 @@ import no.nav.tiltakspenger.libs.dato.mars
 import no.nav.tiltakspenger.libs.dato.september
 import no.nav.tiltakspenger.libs.periode.Periode
 import no.nav.tiltakspenger.libs.periode.til
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.GenererMeldeperioderFeil
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.MeldeperiodeKjede
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.MeldeperiodeKjeder
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.finnNærmesteMeldeperiode
@@ -31,6 +34,7 @@ import no.nav.tiltakspenger.saksbehandling.omgjøring.Omgjøringsperiode
 import no.nav.tiltakspenger.saksbehandling.vedtak.Rammevedtaksliste
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.time.LocalDate
 
 class MeldeperiodeKjederTest {
 
@@ -39,16 +43,16 @@ class MeldeperiodeKjederTest {
         @Test
         fun `tom kjede finner start dato for en kjede`() {
             val tommeKjeder = MeldeperiodeKjeder(emptyList())
-            tommeKjeder.finnNærmesteMeldeperiode(2.januar(2023)) shouldBe Periode(2.januar(2023), 15.januar(2023))
-            tommeKjeder.finnNærmesteMeldeperiode(7.april(2024)) shouldBe Periode(1.april(2024), 14.april(2024))
-            tommeKjeder.finnNærmesteMeldeperiode(8.april(2024)) shouldBe Periode(8.april(2024), 21.april(2024))
-            tommeKjeder.finnNærmesteMeldeperiode(9.april(2024)) shouldBe Periode(8.april(2024), 21.april(2024))
-            tommeKjeder.finnNærmesteMeldeperiode(10.april(2024)) shouldBe Periode(8.april(2024), 21.april(2024))
-            tommeKjeder.finnNærmesteMeldeperiode(11.april(2024)) shouldBe Periode(8.april(2024), 21.april(2024))
-            tommeKjeder.finnNærmesteMeldeperiode(12.april(2024)) shouldBe Periode(8.april(2024), 21.april(2024))
-            tommeKjeder.finnNærmesteMeldeperiode(13.april(2024)) shouldBe Periode(8.april(2024), 21.april(2024))
-            tommeKjeder.finnNærmesteMeldeperiode(14.april(2024)) shouldBe Periode(8.april(2024), 21.april(2024))
-            tommeKjeder.finnNærmesteMeldeperiode(15.april(2024)) shouldBe Periode(15.april(2024), 28.april(2024))
+            tommeKjeder.finnNærmesteMeldeperiode(2.januar(2023)) shouldBe Periode(2.januar(2023), 15.januar(2023)).right()
+            tommeKjeder.finnNærmesteMeldeperiode(7.april(2024)) shouldBe Periode(1.april(2024), 14.april(2024)).right()
+            tommeKjeder.finnNærmesteMeldeperiode(8.april(2024)) shouldBe Periode(8.april(2024), 21.april(2024)).right()
+            tommeKjeder.finnNærmesteMeldeperiode(9.april(2024)) shouldBe Periode(8.april(2024), 21.april(2024)).right()
+            tommeKjeder.finnNærmesteMeldeperiode(10.april(2024)) shouldBe Periode(8.april(2024), 21.april(2024)).right()
+            tommeKjeder.finnNærmesteMeldeperiode(11.april(2024)) shouldBe Periode(8.april(2024), 21.april(2024)).right()
+            tommeKjeder.finnNærmesteMeldeperiode(12.april(2024)) shouldBe Periode(8.april(2024), 21.april(2024)).right()
+            tommeKjeder.finnNærmesteMeldeperiode(13.april(2024)) shouldBe Periode(8.april(2024), 21.april(2024)).right()
+            tommeKjeder.finnNærmesteMeldeperiode(14.april(2024)) shouldBe Periode(8.april(2024), 21.april(2024)).right()
+            tommeKjeder.finnNærmesteMeldeperiode(15.april(2024)) shouldBe Periode(15.april(2024), 28.april(2024)).right()
         }
 
         @Test
@@ -56,8 +60,8 @@ class MeldeperiodeKjederTest {
             val kjeder = MeldeperiodeKjeder(
                 MeldeperiodeKjede(ObjectMother.meldeperiode(periode = Periode(20.januar(2025), 2.februar(2025)))),
             )
-            kjeder.finnNærmesteMeldeperiode(6.januar(2025)) shouldBe Periode(6.januar(2025), 19.januar(2025))
-            kjeder.finnNærmesteMeldeperiode(19.januar(2025)) shouldBe Periode(6.januar(2025), 19.januar(2025))
+            kjeder.finnNærmesteMeldeperiode(6.januar(2025)) shouldBe Periode(6.januar(2025), 19.januar(2025)).right()
+            kjeder.finnNærmesteMeldeperiode(19.januar(2025)) shouldBe Periode(6.januar(2025), 19.januar(2025)).right()
         }
 
         @Test
@@ -65,8 +69,8 @@ class MeldeperiodeKjederTest {
             val kjeder = MeldeperiodeKjeder(
                 MeldeperiodeKjede(ObjectMother.meldeperiode(periode = Periode(20.januar(2025), 2.februar(2025)))),
             )
-            kjeder.finnNærmesteMeldeperiode(23.desember(2024)) shouldBe Periode(23.desember(2024), 5.januar(2025))
-            kjeder.finnNærmesteMeldeperiode(5.januar(2025)) shouldBe Periode(23.desember(2024), 5.januar(2025))
+            kjeder.finnNærmesteMeldeperiode(23.desember(2024)) shouldBe Periode(23.desember(2024), 5.januar(2025)).right()
+            kjeder.finnNærmesteMeldeperiode(5.januar(2025)) shouldBe Periode(23.desember(2024), 5.januar(2025)).right()
         }
 
         @Test
@@ -77,7 +81,7 @@ class MeldeperiodeKjederTest {
             kjeder.finnNærmesteMeldeperiode(25.januar(2025)) shouldBe Periode(
                 20.januar(2025),
                 2.februar(2025),
-            )
+            ).right()
         }
 
         @Test
@@ -85,8 +89,8 @@ class MeldeperiodeKjederTest {
             val kjeder = MeldeperiodeKjeder(
                 MeldeperiodeKjede(ObjectMother.meldeperiode(periode = Periode(20.januar(2025), 2.februar(2025)))),
             )
-            kjeder.finnNærmesteMeldeperiode(3.februar(2025)) shouldBe Periode(3.februar(2025), 16.februar(2025))
-            kjeder.finnNærmesteMeldeperiode(16.februar(2025)) shouldBe Periode(3.februar(2025), 16.februar(2025))
+            kjeder.finnNærmesteMeldeperiode(3.februar(2025)) shouldBe Periode(3.februar(2025), 16.februar(2025)).right()
+            kjeder.finnNærmesteMeldeperiode(16.februar(2025)) shouldBe Periode(3.februar(2025), 16.februar(2025)).right()
         }
 
         @Test
@@ -94,8 +98,8 @@ class MeldeperiodeKjederTest {
             val kjeder = MeldeperiodeKjeder(
                 MeldeperiodeKjede(ObjectMother.meldeperiode(periode = Periode(20.januar(2025), 2.februar(2025)))),
             )
-            kjeder.finnNærmesteMeldeperiode(17.februar(2025)) shouldBe Periode(17.februar(2025), 2.mars(2025))
-            kjeder.finnNærmesteMeldeperiode(2.mars(2025)) shouldBe Periode(17.februar(2025), 2.mars(2025))
+            kjeder.finnNærmesteMeldeperiode(17.februar(2025)) shouldBe Periode(17.februar(2025), 2.mars(2025)).right()
+            kjeder.finnNærmesteMeldeperiode(2.mars(2025)) shouldBe Periode(17.februar(2025), 2.mars(2025)).right()
         }
 
         @Test
@@ -103,8 +107,21 @@ class MeldeperiodeKjederTest {
             val kjeder = MeldeperiodeKjeder(
                 MeldeperiodeKjede(ObjectMother.meldeperiode(periode = Periode(6.januar(2025), 19.januar(2025)))),
             )
-            kjeder.finnNærmesteMeldeperiode(6.januar(2025)) shouldBe Periode(6.januar(2025), 19.januar(2025))
-            kjeder.finnNærmesteMeldeperiode(19.januar(2025)) shouldBe Periode(6.januar(2025), 19.januar(2025))
+            kjeder.finnNærmesteMeldeperiode(6.januar(2025)) shouldBe Periode(6.januar(2025), 19.januar(2025)).right()
+            kjeder.finnNærmesteMeldeperiode(19.januar(2025)) shouldBe Periode(6.januar(2025), 19.januar(2025)).right()
+        }
+
+        @Test
+        fun `LocalDate MIN og MAX gir UgyldigDato`() {
+            val tommeKjeder = MeldeperiodeKjeder(emptyList())
+            tommeKjeder.finnNærmesteMeldeperiode(LocalDate.MIN) shouldBe GenererMeldeperioderFeil.UgyldigDato.left()
+            tommeKjeder.finnNærmesteMeldeperiode(LocalDate.MAX) shouldBe GenererMeldeperioderFeil.UgyldigDato.left()
+
+            val kjeder = MeldeperiodeKjeder(
+                MeldeperiodeKjede(ObjectMother.meldeperiode(periode = Periode(6.januar(2025), 19.januar(2025)))),
+            )
+            kjeder.finnNærmesteMeldeperiode(LocalDate.MIN) shouldBe GenererMeldeperioderFeil.UgyldigDato.left()
+            kjeder.finnNærmesteMeldeperiode(LocalDate.MAX) shouldBe GenererMeldeperioderFeil.UgyldigDato.left()
         }
     }
 
@@ -124,7 +141,7 @@ class MeldeperiodeKjederTest {
                 innvilgelseVedtak,
             ),
             fixedClock,
-        )
+        ).getOrNull()!!
 
         val forventetFørstePeriode = Periode(2.januar(2023), 15.januar(2023))
         val forventetSistePeriode = Periode(16.januar(2023), 29.januar(2023))
@@ -186,7 +203,7 @@ class MeldeperiodeKjederTest {
 
         val kjeder = MeldeperiodeKjeder(emptyList())
 
-        val actual = kjeder.genererMeldeperioderOgOppdaterKjeder(vedtaksliste, fixedClock)
+        val actual = kjeder.genererMeldeperioderOgOppdaterKjeder(vedtaksliste, fixedClock).getOrNull()!!
 
         actual.let {
             it.first.size shouldBe 0
@@ -215,7 +232,7 @@ class MeldeperiodeKjederTest {
         val forventetFørstePeriode = Periode(2.januar(2023), 15.januar(2023))
         val forventetSistePeriode = Periode(16.januar(2023), 29.januar(2023))
 
-        val (nyeKjederV1) = kjederV1.genererMeldeperioderOgOppdaterKjeder(v1, fixedClock).also {
+        val (nyeKjederV1) = kjederV1.genererMeldeperioderOgOppdaterKjeder(v1, fixedClock).getOrNull()!!.also {
             it.first.sisteMeldeperiodePerKjede.size shouldBe 2
             it.first.sisteMeldeperiodePerKjede shouldBe it.second
 
@@ -259,7 +276,7 @@ class MeldeperiodeKjederTest {
             ),
         )
 
-        val actual = nyeKjederV1.genererMeldeperioderOgOppdaterKjeder(v2, enUkeEtterFixedClock)
+        val actual = nyeKjederV1.genererMeldeperioderOgOppdaterKjeder(v2, enUkeEtterFixedClock).getOrNull()!!
 
         actual.let {
             it.first.sisteMeldeperiodePerKjede.size shouldBe 2
@@ -354,7 +371,7 @@ class MeldeperiodeKjederTest {
                 innvilgelseVedtak,
             ),
             fixedClock,
-        )
+        ).getOrNull()!!
 
         val forventetFørstePeriode = Periode(2.januar(2023), 15.januar(2023))
         val forventetSistePeriode = Periode(16.januar(2023), 29.januar(2023))
@@ -371,6 +388,85 @@ class MeldeperiodeKjederTest {
 
             it.first.sisteMeldeperiodePerKjede.last().antallDagerSomGirRett shouldBe 2
             it.first.sisteMeldeperiodePerKjede.last().maksAntallDagerForMeldeperiode shouldBe 2
+        }
+    }
+
+    @Test
+    fun `tom vedtaksliste og tomme kjeder gir tomt resultat`() {
+        val kjeder = MeldeperiodeKjeder(emptyList())
+
+        val actual = kjeder.genererMeldeperioderOgOppdaterKjeder(Rammevedtaksliste(emptyList()), fixedClock).getOrNull()!!
+
+        actual.first shouldBe kjeder
+        actual.second shouldBe emptyList()
+    }
+
+    @Test
+    fun `tom vedtaksliste men eksisterende kjeder gir feil`() {
+        val kjeder = MeldeperiodeKjeder(
+            MeldeperiodeKjede(ObjectMother.meldeperiode(periode = Periode(2.januar(2023), 15.januar(2023)))),
+        )
+
+        kjeder.genererMeldeperioderOgOppdaterKjeder(Rammevedtaksliste(emptyList()), fixedClock) shouldBe
+            GenererMeldeperioderFeil.HarMeldeperioderUtenVedtaksperioder.left()
+    }
+
+    @Test
+    fun `kjøring med uendret vedtaksliste lager ingen nye versjoner (idempotent)`() {
+        val sakId = SakId.random()
+        val periode = Periode(2.januar(2023), 17.januar(2023))
+        val innvilgelseVedtak = ObjectMother.nyRammevedtakInnvilgelse(
+            sakId = sakId,
+            innvilgelsesperioder = listOf(
+                innvilgelsesperiodeKommando(innvilgelsesperiode = periode),
+            ),
+        )
+        val vedtaksliste = Rammevedtaksliste(innvilgelseVedtak)
+
+        val (kjederEtterFørste, nyeFørste) =
+            MeldeperiodeKjeder(emptyList()).genererMeldeperioderOgOppdaterKjeder(vedtaksliste, fixedClock).getOrNull()!!
+
+        nyeFørste.size shouldBe 2
+        kjederEtterFørste.sisteMeldeperiodePerKjede.forEach { it.versjon shouldBe HendelseVersjon(1) }
+
+        val (kjederEtterAndre, nyeAndre) =
+            kjederEtterFørste.genererMeldeperioderOgOppdaterKjeder(vedtaksliste, fixedClock).getOrNull()!!
+
+        // Ingen endringer -> ingen nye meldeperioder og kjedene er uendret
+        nyeAndre shouldBe emptyList()
+        kjederEtterAndre shouldBe kjederEtterFørste
+        kjederEtterAndre.sisteMeldeperiodePerKjede.forEach { it.versjon shouldBe HendelseVersjon(1) }
+    }
+
+    @Test
+    fun `maks antall dager kappes når innvilgelsesperioden bare delvis dekker meldeperioden`() {
+        val sakId = SakId.random()
+        // 2. januar 2023 er en mandag. Innvilger kun mandag og tirsdag, altså 2 dager med rett
+        // i en meldeperiode som strekker seg 2. - 15. januar.
+        val innvilgelsesperiode = Periode(2.januar(2023), 3.januar(2023))
+        val kjeder = MeldeperiodeKjeder(emptyList())
+        val innvilgelseVedtak = ObjectMother.nyRammevedtakInnvilgelse(
+            sakId = sakId,
+            innvilgelsesperioder = listOf(
+                innvilgelsesperiodeKommando(
+                    innvilgelsesperiode = innvilgelsesperiode,
+                    antallDagerPerMeldeperiode = 10,
+                ),
+            ),
+        )
+
+        val actual =
+            kjeder.genererMeldeperioderOgOppdaterKjeder(Rammevedtaksliste(innvilgelseVedtak), fixedClock).getOrNull()!!
+
+        actual.let {
+            it.first.size shouldBe 1
+            it.first.sisteMeldeperiodePerKjede shouldBe it.second
+
+            val meldeperiode = it.first.sisteMeldeperiodePerKjede.single()
+            meldeperiode.periode shouldBe Periode(2.januar(2023), 15.januar(2023))
+            meldeperiode.antallDagerSomGirRett shouldBe 2
+            // Selv om vedtaket tillater 10 dager, kappes maks til antall dager som faktisk gir rett.
+            meldeperiode.maksAntallDagerForMeldeperiode shouldBe 2
         }
     }
 }

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldeperiode/GenererMeldeperioderForValideringTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldeperiode/GenererMeldeperioderForValideringTest.kt
@@ -1,0 +1,41 @@
+package no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode
+
+import arrow.core.left
+import io.kotest.matchers.shouldBe
+import no.nav.tiltakspenger.libs.common.fixedClock
+import no.nav.tiltakspenger.saksbehandling.objectmothers.ObjectMother
+import org.junit.jupiter.api.Test
+
+class GenererMeldeperioderForValideringTest {
+
+    @Test
+    fun `genererer meldeperioder for en ikke-vedtatt behandling med vedtaksperiode`() {
+        val (sak, behandling) = ObjectMother.sakMedOpprettetBehandling()
+
+        val actual = sak.genererMeldeperioderForValidering(behandling, fixedClock)
+
+        actual.isRight() shouldBe true
+        actual.getOrNull()!!.isNotEmpty() shouldBe true
+    }
+
+    @Test
+    fun `behandling uten vedtaksperiode gir BehandlingManglerVedtaksperiode`() {
+        val (sak, _) = ObjectMother.sakMedOpprettetBehandling()
+        // En nyopprettet søknadsbehandling har ikke valgt resultat enda, og dermed ingen vedtaksperiode.
+        val behandlingUtenVedtaksperiode = ObjectMother.nyOpprettetSøknadsbehandling()
+        behandlingUtenVedtaksperiode.vedtaksperiode shouldBe null
+
+        sak.genererMeldeperioderForValidering(behandlingUtenVedtaksperiode, fixedClock) shouldBe
+            GenererMeldeperioderFeil.BehandlingManglerVedtaksperiode.left()
+    }
+
+    @Test
+    fun `vedtatt behandling gir FeilKallForVedtattBehandling`() {
+        val (sak, _) = ObjectMother.sakMedOpprettetBehandling()
+        // For vedtatte behandlinger skal meldeperioder genereres ut fra vedtak på saken, ikke behandlingen.
+        val vedtattBehandling = ObjectMother.nyVedtattSøknadsbehandling()
+
+        sak.genererMeldeperioderForValidering(vedtattBehandling, fixedClock) shouldBe
+            GenererMeldeperioderFeil.FeilKallForVedtattBehandling.left()
+    }
+}

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldeperiode/GenererMeldeperioderSammenligningTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldeperiode/GenererMeldeperioderSammenligningTest.kt
@@ -1,0 +1,154 @@
+package no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode
+
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import no.nav.tiltakspenger.libs.common.CorrelationId
+import no.nav.tiltakspenger.libs.common.VedtakId
+import no.nav.tiltakspenger.libs.common.fixedClock
+import no.nav.tiltakspenger.libs.common.getOrFail
+import no.nav.tiltakspenger.libs.dato.januar
+import no.nav.tiltakspenger.libs.dato.mars
+import no.nav.tiltakspenger.libs.periode.Periode
+import no.nav.tiltakspenger.saksbehandling.objectmothers.ObjectMother
+import no.nav.tiltakspenger.saksbehandling.objectmothers.tilBeslutning
+import no.nav.tiltakspenger.saksbehandling.vedtak.opprettRammevedtak
+import org.junit.jupiter.api.Test
+import java.time.Clock
+
+/**
+ * Verifiserer at [genererMeldeperioderForValidering] (kjøres på en ikke-vedtatt behandling) og
+ * [genererMeldeperioderOgOppdaterKjeder] (kjøres på saken etter at behandlingen er iverksatt) produserer
+ * de samme meldeperiodene.
+ *
+ * De eneste forventede forskjellene er vedtak-id-ene: under validering brukes en tilfeldig [VedtakId] for
+ * behandlingens periode, mens den faktiske genereringen bruker vedtak-id-en til det iverksatte rammevedtaket.
+ * [no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.Meldeperiode.erLik] ignorerer derfor
+ * `rammevedtak` (samt `id`, `versjon` og `opprettet`) og brukes til selve sammenligningen.
+ */
+class GenererMeldeperioderSammenligningTest {
+
+    @Test
+    fun `gir like meldeperioder for en enkel vedtaksperiode`() {
+        val grunnlag = byggSammenligningsgrunnlag(
+            vedtaksperiode = Periode(1.januar(2023), 31.januar(2023)),
+        )
+
+        grunnlag.valideringMeldeperioder.isNotEmpty() shouldBe true
+        assertMeldeperioderErLike(
+            forventet = grunnlag.valideringMeldeperioder,
+            faktisk = grunnlag.vedtattMeldeperioder,
+        )
+    }
+
+    @Test
+    fun `gir like meldeperioder for en vedtaksperiode som strekker seg over flere meldeperioder`() {
+        val grunnlag = byggSammenligningsgrunnlag(
+            vedtaksperiode = Periode(1.januar(2023), 31.mars(2023)),
+        )
+
+        // En periode på 3 måneder skal gi flere meldeperioder
+        (grunnlag.valideringMeldeperioder.size > 1) shouldBe true
+        assertMeldeperioderErLike(
+            forventet = grunnlag.valideringMeldeperioder,
+            faktisk = grunnlag.vedtattMeldeperioder,
+        )
+    }
+
+    @Test
+    fun `meldeperiodene er like bortsett fra vedtak-id-ene`() {
+        val grunnlag = byggSammenligningsgrunnlag(
+            vedtaksperiode = Periode(1.januar(2023), 31.januar(2023)),
+        )
+
+        // De faktiske meldeperiodene peker på det iverksatte rammevedtaket ...
+        val vedtattVedtakIder = grunnlag.vedtattMeldeperioder.flatMap { it.rammevedtak.verdier }.toSet()
+        vedtattVedtakIder shouldBe setOf(grunnlag.rammevedtakId)
+
+        // ... mens valideringsmeldeperiodene bruker tilfeldige vedtak-id-er
+        val valideringVedtakIder = grunnlag.valideringMeldeperioder.flatMap { it.rammevedtak.verdier }.toSet()
+        valideringVedtakIder shouldNotContain grunnlag.rammevedtakId
+
+        // Alt annet enn vedtak-id-ene skal være likt
+        assertMeldeperioderErLike(
+            forventet = grunnlag.valideringMeldeperioder,
+            faktisk = grunnlag.vedtattMeldeperioder,
+        )
+    }
+
+    private data class Sammenligningsgrunnlag(
+        val valideringMeldeperioder: List<Meldeperiode>,
+        val vedtattMeldeperioder: List<Meldeperiode>,
+        val rammevedtakId: VedtakId,
+    )
+
+    /**
+     * Bygger opp en sak med én søknadsbehandling, og kjører begge genereringsfunksjonene:
+     *  1. [genererMeldeperioderForValidering] mens behandlingen er under beslutning (ikke vedtatt)
+     *  2. [genererMeldeperioderOgOppdaterKjeder] etter at den samme behandlingen er iverksatt og lagt på saken
+     */
+    private fun byggSammenligningsgrunnlag(
+        vedtaksperiode: Periode,
+        clock: Clock = fixedClock,
+    ): Sammenligningsgrunnlag {
+        val saksbehandler = ObjectMother.saksbehandler()
+        val beslutter = ObjectMother.beslutter()
+
+        val (sak, behandling) = ObjectMother.sakMedOpprettetBehandling(
+            vedtaksperiode = vedtaksperiode,
+            saksbehandler = saksbehandler,
+            clock = clock,
+        )
+
+        // Sett behandlingen i en pre-vedtatt tilstand (under beslutning)
+        val behandlingUnderBeslutning = behandling
+            .tilBeslutning(saksbehandler = saksbehandler, clock = clock)
+            .taBehandling(beslutter, clock)
+            .first
+
+        // 1. Generer meldeperioder for validering ut fra den ikke-vedtatte behandlingen
+        val valideringMeldeperioder = sak
+            .genererMeldeperioderForValidering(behandlingUnderBeslutning, clock)
+            .getOrFail()
+
+        // Iverksett behandlingen (gir status VEDTATT) og opprett rammevedtaket på saken
+        val iverksattBehandling = behandlingUnderBeslutning.iverksett(
+            utøvendeBeslutter = beslutter,
+            attestering = ObjectMother.godkjentAttestering(beslutter, clock),
+            correlationId = CorrelationId.generate(),
+            clock = clock,
+        ).first
+
+        val (sakMedVedtak, rammevedtak) = sak.oppdaterRammebehandling(iverksattBehandling)
+            .opprettRammevedtak(iverksattBehandling, clock)
+            .getOrFail()
+
+        // 2. Generer de faktiske meldeperiodene ut fra rammevedtaket på saken
+        val vedtattMeldeperioder = sakMedVedtak.meldeperiodeKjeder
+            .genererMeldeperioderOgOppdaterKjeder(sakMedVedtak.rammevedtaksliste, clock)
+            .getOrFail()
+            .second
+
+        return Sammenligningsgrunnlag(
+            valideringMeldeperioder = valideringMeldeperioder,
+            vedtattMeldeperioder = vedtattMeldeperioder,
+            rammevedtakId = rammevedtak.id,
+        )
+    }
+
+    private fun assertMeldeperioderErLike(
+        forventet: List<Meldeperiode>,
+        faktisk: List<Meldeperiode>,
+    ) {
+        faktisk.size shouldBe forventet.size
+
+        forventet.zip(faktisk).forEach { (forventetMp, faktiskMp) ->
+            withClue("Meldeperiode for ${forventetMp.periode} skal være lik (bortsett fra vedtak-id-er)") {
+                faktiskMp.erLik(forventetMp) shouldBe true
+                faktiskMp.periode shouldBe forventetMp.periode
+                faktiskMp.maksAntallDagerForMeldeperiode shouldBe forventetMp.maksAntallDagerForMeldeperiode
+                faktiskMp.girRett shouldBe forventetMp.girRett
+            }
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/GenererMeldeperioderSakIT.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/GenererMeldeperioderSakIT.kt
@@ -147,6 +147,10 @@ class GenererMeldeperioderSakIT {
                 it.alleMeldeperioder.forEach { mp -> mp.versjon shouldBe HendelseVersjon(1) }
             }
 
+            // Den andre innvilgelsen starter søndag 1. juni 2025, slik at den første meldeperioden (19. mai - 1. juni)
+            // kun har rett i helg. Saken må derfor kunne sende inn helg for at meldeperiodene skal være gyldige.
+            tac.sakContext.sakRepo.oppdaterKanSendeInnHelgForMeldekort(sak.id, true)
+
             val (oppdatertSak) = this.iverksettSøknadsbehandling(
                 tac = tac,
                 fnr = fnr,


### PR DESCRIPTION
- Tillater ikke å oppdatere, sende til beslutning eller iverksette behandlinger dersom det fører til meldeperioder der det kun er rett på helgedager, med mindre saken er flagget for melding i helg.
- Tillater ikke å slå av melding i helg på saken dersom det finnes meldeperioder som kun har rett på helgedager
- Refaktor generering av meldeperioder til mer funksjonell stil, og for å kunne gjenbruke logikken til validering