### PR TITLE
Refactor handlinger på meldekortbehandling, og gjenbruk valideringslogikk til frontend

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/klage/infra/route/opprettBehandling/OpprettBehandlingForKlageRoute.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/klage/infra/route/opprettBehandling/OpprettBehandlingForKlageRoute.kt
@@ -163,6 +163,7 @@ fun Route.opprettBehandlingForKlageRoute(
                                             beregninger = it.sak.meldeperiodeBeregninger,
                                             hentVedtak = it.sak.meldekortvedtaksliste::hentForMeldekortbehandling,
                                             hentTilbakekreving = it.sak::hentTilbakekrevingForMeldekortbehandling,
+                                            kallendeSaksbehandler = saksbehandler,
                                         ),
                                     )
                                 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/klage/service/GjenopptaKlagebehandlingService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/klage/service/GjenopptaKlagebehandlingService.kt
@@ -1,6 +1,7 @@
 package no.nav.tiltakspenger.saksbehandling.klage.service
 
 import arrow.core.Either
+import arrow.core.getOrElse
 import no.nav.tiltakspenger.libs.persistering.domene.SessionFactory
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.AttesterbarBehandling
 import no.nav.tiltakspenger.saksbehandling.behandling.service.behandling.GjenopptaRammebehandlingService
@@ -36,7 +37,13 @@ class GjenopptaKlagebehandlingService(
             gjenopptaRammebehandling = { gjenopptaKommando ->
                 gjenopptaRammebehandlingService.gjenopptaBehandlingFraKlage(gjenopptaKommando).getOrThrow()
             },
-            gjenopptaMeldekortbehandling = gjenopptaMeldekortbehandlingService::gjenoppta,
+            gjenopptaMeldekortbehandling = { gjenopptaKommando ->
+                gjenopptaMeldekortbehandlingService.gjenoppta(gjenopptaKommando).getOrElse {
+                    throw IllegalStateException(
+                        "Kunne ikke gjenoppta meldekortbehandling ${gjenopptaKommando.meldekortId} tilknyttet klagebehandling ${kommando.klagebehandlingId}: $it",
+                    )
+                }
+            },
             lagre = ::lagreKlagebehandlingOgStatistikk,
         )
     }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/klage/service/LeggTilbakeKlagebehandlingService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/klage/service/LeggTilbakeKlagebehandlingService.kt
@@ -1,6 +1,7 @@
 package no.nav.tiltakspenger.saksbehandling.klage.service
 
 import arrow.core.Either
+import arrow.core.getOrElse
 import no.nav.tiltakspenger.libs.persistering.domene.SessionFactory
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.AttesterbarBehandling
 import no.nav.tiltakspenger.saksbehandling.behandling.service.behandling.LeggTilbakeRammebehandlingService
@@ -33,7 +34,17 @@ class LeggTilbakeKlagebehandlingService(
             kommando = kommando,
             clock = clock,
             leggTilbakeRammebehandling = leggTilbakeRammebehandlingService::leggTilbakeRammebehandling,
-            leggTilbakeMeldekortbehandling = leggTilbakeMeldekortbehandlingService::leggTilbakeMeldekortbehandling,
+            leggTilbakeMeldekortbehandling = { sakId, meldekortId, saksbehandlerSomLeggerTilbake ->
+                leggTilbakeMeldekortbehandlingService.leggTilbakeMeldekortbehandling(
+                    sakId,
+                    meldekortId,
+                    saksbehandlerSomLeggerTilbake,
+                ).getOrElse {
+                    throw IllegalStateException(
+                        "Kunne ikke legge tilbake meldekortbehandling $meldekortId tilknyttet klagebehandling ${kommando.klagebehandlingId}: $it",
+                    )
+                }
+            },
             lagre = ::lagreKlagebehandlingOgStatistikk,
         )
     }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/klage/service/SettKlagebehandlingPåVentService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/klage/service/SettKlagebehandlingPåVentService.kt
@@ -1,6 +1,7 @@
 package no.nav.tiltakspenger.saksbehandling.klage.service
 
 import arrow.core.Either
+import arrow.core.getOrElse
 import no.nav.tiltakspenger.libs.persistering.domene.SessionFactory
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.AttesterbarBehandling
 import no.nav.tiltakspenger.saksbehandling.behandling.service.behandling.SettRammebehandlingPåVentService
@@ -33,7 +34,13 @@ class SettKlagebehandlingPåVentService(
             kommando = kommando,
             clock = clock,
             settRammebehandlingPåVent = settRammebehandlingPåVentService::settBehandlingPåVentFraKlage,
-            settMeldekortbehandlingPåVent = settMeldekortbehandlingPåVentService::settPåVent,
+            settMeldekortbehandlingPåVent = { settPåVentKommando ->
+                settMeldekortbehandlingPåVentService.settPåVent(settPåVentKommando).getOrElse {
+                    throw IllegalStateException(
+                        "Kunne ikke sette meldekortbehandling ${settPåVentKommando.meldekortId} tilknyttet klagebehandling ${kommando.klagebehandlingId} på vent: $it",
+                    )
+                }
+            },
             lagre = ::lagreKlagebehandlingOgStatistikk,
         )
     }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/Meldekortbehandling.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/Meldekortbehandling.kt
@@ -1,12 +1,10 @@
 package no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling
 
-import arrow.core.Either
 import arrow.core.NonEmptyList
 import arrow.core.NonEmptySet
 import no.nav.tiltakspenger.libs.common.Fnr
 import no.nav.tiltakspenger.libs.common.MeldekortId
 import no.nav.tiltakspenger.libs.common.SakId
-import no.nav.tiltakspenger.libs.common.Saksbehandler
 import no.nav.tiltakspenger.libs.common.Saksnummer
 import no.nav.tiltakspenger.libs.common.VedtakId
 import no.nav.tiltakspenger.libs.common.nå
@@ -25,8 +23,6 @@ import no.nav.tiltakspenger.saksbehandling.klage.domene.Klagebehandlingsresultat
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.UtfyltMeldeperiode
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.brukersmeldekort.BrukersMeldekort
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.avbryt.avbrytIkkeRettTilTiltakspenger
-import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.overta.KunneIkkeOvertaMeldekortbehandling
-import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.overta.OvertaMeldekortbehandlingKommando
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.Meldeperiode
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldeperiode.MeldeperiodeKjeder
 import no.nav.tiltakspenger.saksbehandling.oppfølgingsenhet.Navkontor
@@ -157,8 +153,6 @@ sealed interface Meldekortbehandling : AttesterbarBehandling {
             is MeldekortbehandlingAvbrutt -> throw IllegalStateException("Avbrutt meldekortbehandling skal alltid ansees som avsluttet")
         }
     }
-
-    fun leggTilbakeMeldekortbehandling(saksbehandler: Saksbehandler, clock: Clock): Meldekortbehandling
 
     fun oppdaterSimulering(simulering: Simulering?): Meldekortbehandling
 

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/Meldekortbehandling.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/Meldekortbehandling.kt
@@ -158,11 +158,6 @@ sealed interface Meldekortbehandling : AttesterbarBehandling {
         }
     }
 
-    fun overta(
-        kommando: OvertaMeldekortbehandlingKommando,
-        clock: Clock,
-    ): Either<KunneIkkeOvertaMeldekortbehandling, Meldekortbehandling>
-
     fun leggTilbakeMeldekortbehandling(saksbehandler: Saksbehandler, clock: Clock): Meldekortbehandling
 
     fun oppdaterSimulering(simulering: Simulering?): Meldekortbehandling

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/Meldekortbehandling.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/Meldekortbehandling.kt
@@ -72,6 +72,8 @@ sealed interface Meldekortbehandling : AttesterbarBehandling {
 
     val kjedeIder: NonEmptySet<MeldeperiodeKjedeId> get() = meldeperioder.kjedeIder
 
+    val erSattPåVent: Boolean get() = ventestatus.erSattPåVent
+
     /** TODO: fjernes når all funksjonalitet for å behandle flere meldeperioder i en behandling er på plass */
     private val førsteMeldeperiodebehandling: Meldeperiodebehandling get() = meldeperioder.first()
     val meldeperiodeLegacy: Meldeperiode get() = førsteMeldeperiodebehandling.meldeperiode

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/MeldekortbehandlingAutomatisk.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/MeldekortbehandlingAutomatisk.kt
@@ -21,8 +21,6 @@ import no.nav.tiltakspenger.saksbehandling.felles.Ventestatus
 import no.nav.tiltakspenger.saksbehandling.infra.setup.AUTOMATISK_SAKSBEHANDLER_ID
 import no.nav.tiltakspenger.saksbehandling.klage.domene.Klagebehandling
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.brukersmeldekort.BrukersMeldekort
-import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.overta.KunneIkkeOvertaMeldekortbehandling
-import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.overta.OvertaMeldekortbehandlingKommando
 import no.nav.tiltakspenger.saksbehandling.oppfølgingsenhet.Navkontor
 import no.nav.tiltakspenger.saksbehandling.sak.Sak
 import no.nav.tiltakspenger.saksbehandling.utbetaling.domene.KunneIkkeSimulere
@@ -76,13 +74,6 @@ data class MeldekortBehandletAutomatisk(
             "Ugyldig status for automatisk behandling: $status"
         }
         require(!ingenDagerGirRett)
-    }
-
-    override fun overta(
-        kommando: OvertaMeldekortbehandlingKommando,
-        clock: Clock,
-    ): Either<KunneIkkeOvertaMeldekortbehandling, Meldekortbehandling> {
-        return KunneIkkeOvertaMeldekortbehandling.KanIkkeOvertaAutomatiskBehandling.left()
     }
 
     override fun leggTilbakeMeldekortbehandling(saksbehandler: Saksbehandler, clock: Clock): Meldekortbehandling {

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/MeldekortbehandlingAutomatisk.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/MeldekortbehandlingAutomatisk.kt
@@ -9,7 +9,6 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.tiltakspenger.libs.common.Fnr
 import no.nav.tiltakspenger.libs.common.MeldekortId
 import no.nav.tiltakspenger.libs.common.SakId
-import no.nav.tiltakspenger.libs.common.Saksbehandler
 import no.nav.tiltakspenger.libs.common.Saksnummer
 import no.nav.tiltakspenger.libs.common.nå
 import no.nav.tiltakspenger.libs.logging.Sikkerlogg
@@ -74,10 +73,6 @@ data class MeldekortBehandletAutomatisk(
             "Ugyldig status for automatisk behandling: $status"
         }
         require(!ingenDagerGirRett)
-    }
-
-    override fun leggTilbakeMeldekortbehandling(saksbehandler: Saksbehandler, clock: Clock): Meldekortbehandling {
-        throw IllegalStateException("Kan ikke legge tilbake automatisk behandlet meldekort")
     }
 
     override fun oppdaterSimulering(simulering: Simulering?): Meldekortbehandling {

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/MeldekortbehandlingAvbrutt.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/MeldekortbehandlingAvbrutt.kt
@@ -3,7 +3,6 @@ package no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling
 import no.nav.tiltakspenger.libs.common.Fnr
 import no.nav.tiltakspenger.libs.common.MeldekortId
 import no.nav.tiltakspenger.libs.common.SakId
-import no.nav.tiltakspenger.libs.common.Saksbehandler
 import no.nav.tiltakspenger.libs.common.Saksnummer
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.FritekstTilVedtaksbrev
 import no.nav.tiltakspenger.saksbehandling.felles.Attesteringer
@@ -13,7 +12,6 @@ import no.nav.tiltakspenger.saksbehandling.felles.Ventestatus
 import no.nav.tiltakspenger.saksbehandling.klage.domene.Klagebehandling
 import no.nav.tiltakspenger.saksbehandling.oppfølgingsenhet.Navkontor
 import no.nav.tiltakspenger.saksbehandling.utbetaling.domene.Simulering
-import java.time.Clock
 import java.time.LocalDateTime
 
 /**
@@ -56,10 +54,6 @@ data class MeldekortbehandlingAvbrutt(
     override val beløpTotal = beregning?.totalBeløp
     override val ordinærBeløp = beregning?.ordinærBeløp
     override val barnetilleggBeløp = beregning?.barnetilleggBeløp
-
-    override fun leggTilbakeMeldekortbehandling(saksbehandler: Saksbehandler, clock: Clock): Meldekortbehandling {
-        throw IllegalStateException("Kan ikke legge tilbake avbrutt meldekortbehandling")
-    }
 
     override fun oppdaterSimulering(simulering: Simulering?): Meldekortbehandling {
         throw IllegalStateException("Kan ikke oppdatere simulering på avbrutt meldekortbehandling")

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/MeldekortbehandlingAvbrutt.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/MeldekortbehandlingAvbrutt.kt
@@ -1,6 +1,5 @@
 package no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling
 
-import arrow.core.Either
 import no.nav.tiltakspenger.libs.common.Fnr
 import no.nav.tiltakspenger.libs.common.MeldekortId
 import no.nav.tiltakspenger.libs.common.SakId
@@ -12,8 +11,6 @@ import no.nav.tiltakspenger.saksbehandling.felles.Avbrutt
 import no.nav.tiltakspenger.saksbehandling.felles.Begrunnelse
 import no.nav.tiltakspenger.saksbehandling.felles.Ventestatus
 import no.nav.tiltakspenger.saksbehandling.klage.domene.Klagebehandling
-import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.overta.KunneIkkeOvertaMeldekortbehandling
-import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.overta.OvertaMeldekortbehandlingKommando
 import no.nav.tiltakspenger.saksbehandling.oppfølgingsenhet.Navkontor
 import no.nav.tiltakspenger.saksbehandling.utbetaling.domene.Simulering
 import java.time.Clock
@@ -59,13 +56,6 @@ data class MeldekortbehandlingAvbrutt(
     override val beløpTotal = beregning?.totalBeløp
     override val ordinærBeløp = beregning?.ordinærBeløp
     override val barnetilleggBeløp = beregning?.barnetilleggBeløp
-
-    override fun overta(
-        kommando: OvertaMeldekortbehandlingKommando,
-        clock: Clock,
-    ): Either<KunneIkkeOvertaMeldekortbehandling, Meldekortbehandling> {
-        throw IllegalStateException("Kan ikke overta avbrutt meldekortbehandling")
-    }
 
     override fun leggTilbakeMeldekortbehandling(saksbehandler: Saksbehandler, clock: Clock): Meldekortbehandling {
         throw IllegalStateException("Kan ikke legge tilbake avbrutt meldekortbehandling")

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/MeldekortbehandlingGyldigeKommandoerEx.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/MeldekortbehandlingGyldigeKommandoerEx.kt
@@ -1,0 +1,51 @@
+package no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling
+
+import no.nav.tiltakspenger.libs.common.Saksbehandler
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus.KLAR_TIL_BEHANDLING
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus.KLAR_TIL_BESLUTNING
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus.UNDER_BEHANDLING
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus.UNDER_BESLUTNING
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.gjenoppta.kanGjenoppta
+import no.nav.tiltakspenger.saksbehandling.saksbehandler.SaksbehandlerBehandlingKommando
+
+/**
+ * Handlinger som en saksbehandler/beslutter kan utføre på en meldekortbehandling.
+ *
+ * Hver kommando evalueres for seg selv via egne `kan...`-funksjoner.
+ */
+fun Meldekortbehandling.gyldigeKommandoer(saksbehandler: Saksbehandler): List<SaksbehandlerBehandlingKommando> {
+    return buildList {
+        if (kanTildelSaksbehandler(saksbehandler)) add(SaksbehandlerBehandlingKommando.TildelSaksbehandler)
+        if (kanOvertaSaksbehandler(saksbehandler)) add(SaksbehandlerBehandlingKommando.OvertaSaksbehandler)
+        if (kanLeggeTilbakeSaksbehandler(saksbehandler)) add(SaksbehandlerBehandlingKommando.LeggTilbakeSaksbehandler)
+        if (kanTildelBeslutter(saksbehandler)) add(SaksbehandlerBehandlingKommando.TildelBeslutter)
+        if (kanOvertaBeslutter(saksbehandler)) add(SaksbehandlerBehandlingKommando.OvertaBeslutter)
+        if (kanLeggeTilbakeBeslutter(saksbehandler)) add(SaksbehandlerBehandlingKommando.LeggTilbakeBeslutter)
+        if (kanGjenoppta(saksbehandler).isRight()) add(SaksbehandlerBehandlingKommando.Gjenoppta)
+    }
+}
+
+private fun Meldekortbehandling.kanTildelSaksbehandler(saksbehandler: Saksbehandler): Boolean =
+    status == KLAR_TIL_BEHANDLING && saksbehandler.erSaksbehandler()
+
+private fun Meldekortbehandling.kanOvertaSaksbehandler(saksbehandler: Saksbehandler): Boolean =
+    status == UNDER_BEHANDLING &&
+        this.saksbehandler != saksbehandler.navIdent &&
+        saksbehandler.erSaksbehandler()
+
+private fun Meldekortbehandling.kanLeggeTilbakeSaksbehandler(saksbehandler: Saksbehandler): Boolean =
+    status == UNDER_BEHANDLING && this.saksbehandler == saksbehandler.navIdent
+
+private fun Meldekortbehandling.kanTildelBeslutter(saksbehandler: Saksbehandler): Boolean =
+    status == KLAR_TIL_BESLUTNING &&
+        saksbehandler.erBeslutter() &&
+        this.saksbehandler != saksbehandler.navIdent
+
+private fun Meldekortbehandling.kanOvertaBeslutter(saksbehandler: Saksbehandler): Boolean =
+    status == UNDER_BESLUTNING &&
+        this.beslutter != saksbehandler.navIdent &&
+        saksbehandler.erBeslutter() &&
+        this.saksbehandler != saksbehandler.navIdent
+
+private fun Meldekortbehandling.kanLeggeTilbakeBeslutter(saksbehandler: Saksbehandler): Boolean =
+    status == UNDER_BESLUTNING && this.beslutter == saksbehandler.navIdent

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/MeldekortbehandlingGyldigeKommandoerEx.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/MeldekortbehandlingGyldigeKommandoerEx.kt
@@ -7,6 +7,7 @@ import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus.UNDER_BESLUTNING
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.avbryt.kanAvbryte
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.gjenoppta.kanGjenoppta
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.leggTilbake.kanLeggeTilbake
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.overta.kanOverta
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.settPåVent.kanSettePåVent
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.ta.kanTaMeldekortbehandling
@@ -17,21 +18,21 @@ import no.nav.tiltakspenger.saksbehandling.saksbehandler.SaksbehandlerBehandling
  *
  * Hver kommando evalueres for seg selv via egne `kan...`-funksjoner.
  */
-fun Meldekortbehandling.gyldigeKommandoer(saksbehandler: Saksbehandler): List<SaksbehandlerBehandlingKommando> {
+fun Meldekortbehandling.finnGyldigeKommandoer(saksbehandler: Saksbehandler): List<SaksbehandlerBehandlingKommando> {
     return buildList {
-        if (kanTildelSaksbehandler(saksbehandler)) add(SaksbehandlerBehandlingKommando.TildelSaksbehandler)
+        if (kanTildeleSaksbehandler(saksbehandler)) add(SaksbehandlerBehandlingKommando.TildelSaksbehandler)
+        if (kanTildeleBeslutter(saksbehandler)) add(SaksbehandlerBehandlingKommando.TildelBeslutter)
         if (kanOvertaSaksbehandler(saksbehandler)) add(SaksbehandlerBehandlingKommando.OvertaSaksbehandler)
-        if (kanLeggeTilbakeSaksbehandler(saksbehandler)) add(SaksbehandlerBehandlingKommando.LeggTilbakeSaksbehandler)
-        if (kanTildelBeslutter(saksbehandler)) add(SaksbehandlerBehandlingKommando.TildelBeslutter)
         if (kanOvertaBeslutter(saksbehandler)) add(SaksbehandlerBehandlingKommando.OvertaBeslutter)
+        if (kanLeggeTilbakeSaksbehandler(saksbehandler)) add(SaksbehandlerBehandlingKommando.LeggTilbakeSaksbehandler)
         if (kanLeggeTilbakeBeslutter(saksbehandler)) add(SaksbehandlerBehandlingKommando.LeggTilbakeBeslutter)
-        if (kanGjenoppta(saksbehandler).isRight()) add(SaksbehandlerBehandlingKommando.Gjenoppta)
         if (kanSettePåVent(saksbehandler).isRight()) add(SaksbehandlerBehandlingKommando.SettPåVent)
-        if (kanAvbryte(saksbehandler).isRight()) add(SaksbehandlerBehandlingKommando.Avslutt)
+        if (kanGjenoppta(saksbehandler).isRight()) add(SaksbehandlerBehandlingKommando.Gjenoppta)
+        if (kanAvbryte(saksbehandler).isRight()) add(SaksbehandlerBehandlingKommando.Avbryt)
     }
 }
 
-private fun Meldekortbehandling.kanTildelSaksbehandler(saksbehandler: Saksbehandler): Boolean =
+private fun Meldekortbehandling.kanTildeleSaksbehandler(saksbehandler: Saksbehandler): Boolean =
     status == KLAR_TIL_BEHANDLING && kanTaMeldekortbehandling(saksbehandler).isRight()
 
 private fun Meldekortbehandling.kanOvertaSaksbehandler(saksbehandler: Saksbehandler): Boolean =
@@ -40,9 +41,9 @@ private fun Meldekortbehandling.kanOvertaSaksbehandler(saksbehandler: Saksbehand
         kanOverta(saksbehandler).isRight()
 
 private fun Meldekortbehandling.kanLeggeTilbakeSaksbehandler(saksbehandler: Saksbehandler): Boolean =
-    status == UNDER_BEHANDLING && this.saksbehandler == saksbehandler.navIdent
+    status == UNDER_BEHANDLING && kanLeggeTilbake(saksbehandler).isRight()
 
-private fun Meldekortbehandling.kanTildelBeslutter(saksbehandler: Saksbehandler): Boolean =
+private fun Meldekortbehandling.kanTildeleBeslutter(saksbehandler: Saksbehandler): Boolean =
     status == KLAR_TIL_BESLUTNING && kanTaMeldekortbehandling(saksbehandler).isRight()
 
 private fun Meldekortbehandling.kanOvertaBeslutter(saksbehandler: Saksbehandler): Boolean =
@@ -51,4 +52,4 @@ private fun Meldekortbehandling.kanOvertaBeslutter(saksbehandler: Saksbehandler)
         kanOverta(saksbehandler).isRight()
 
 private fun Meldekortbehandling.kanLeggeTilbakeBeslutter(saksbehandler: Saksbehandler): Boolean =
-    status == UNDER_BESLUTNING && this.beslutter == saksbehandler.navIdent
+    status == UNDER_BESLUTNING && kanLeggeTilbake(saksbehandler).isRight()

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/MeldekortbehandlingGyldigeKommandoerEx.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/MeldekortbehandlingGyldigeKommandoerEx.kt
@@ -7,6 +7,7 @@ import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus.UNDER_BESLUTNING
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.avbryt.kanAvbryte
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.gjenoppta.kanGjenoppta
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.settPåVent.kanSettePåVent
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.ta.kanTaMeldekortbehandling
 import no.nav.tiltakspenger.saksbehandling.saksbehandler.SaksbehandlerBehandlingKommando
 
@@ -24,6 +25,7 @@ fun Meldekortbehandling.gyldigeKommandoer(saksbehandler: Saksbehandler): List<Sa
         if (kanOvertaBeslutter(saksbehandler)) add(SaksbehandlerBehandlingKommando.OvertaBeslutter)
         if (kanLeggeTilbakeBeslutter(saksbehandler)) add(SaksbehandlerBehandlingKommando.LeggTilbakeBeslutter)
         if (kanGjenoppta(saksbehandler).isRight()) add(SaksbehandlerBehandlingKommando.Gjenoppta)
+        if (kanSettePåVent(saksbehandler).isRight()) add(SaksbehandlerBehandlingKommando.SettPåVent)
         if (kanAvbryte(saksbehandler).isRight()) add(SaksbehandlerBehandlingKommando.Avslutt)
     }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/MeldekortbehandlingGyldigeKommandoerEx.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/MeldekortbehandlingGyldigeKommandoerEx.kt
@@ -6,6 +6,7 @@ import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus.UNDER_BEHANDLING
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus.UNDER_BESLUTNING
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.gjenoppta.kanGjenoppta
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.ta.kanTaMeldekortbehandling
 import no.nav.tiltakspenger.saksbehandling.saksbehandler.SaksbehandlerBehandlingKommando
 
 /**
@@ -26,7 +27,7 @@ fun Meldekortbehandling.gyldigeKommandoer(saksbehandler: Saksbehandler): List<Sa
 }
 
 private fun Meldekortbehandling.kanTildelSaksbehandler(saksbehandler: Saksbehandler): Boolean =
-    status == KLAR_TIL_BEHANDLING && saksbehandler.erSaksbehandler()
+    status == KLAR_TIL_BEHANDLING && kanTaMeldekortbehandling(saksbehandler).isRight()
 
 private fun Meldekortbehandling.kanOvertaSaksbehandler(saksbehandler: Saksbehandler): Boolean =
     status == UNDER_BEHANDLING &&
@@ -37,9 +38,7 @@ private fun Meldekortbehandling.kanLeggeTilbakeSaksbehandler(saksbehandler: Saks
     status == UNDER_BEHANDLING && this.saksbehandler == saksbehandler.navIdent
 
 private fun Meldekortbehandling.kanTildelBeslutter(saksbehandler: Saksbehandler): Boolean =
-    status == KLAR_TIL_BESLUTNING &&
-        saksbehandler.erBeslutter() &&
-        this.saksbehandler != saksbehandler.navIdent
+    status == KLAR_TIL_BESLUTNING && kanTaMeldekortbehandling(saksbehandler).isRight()
 
 private fun Meldekortbehandling.kanOvertaBeslutter(saksbehandler: Saksbehandler): Boolean =
     status == UNDER_BESLUTNING &&

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/MeldekortbehandlingGyldigeKommandoerEx.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/MeldekortbehandlingGyldigeKommandoerEx.kt
@@ -15,8 +15,6 @@ import no.nav.tiltakspenger.saksbehandling.saksbehandler.SaksbehandlerBehandling
 
 /**
  * Handlinger som en saksbehandler/beslutter kan utføre på en meldekortbehandling.
- *
- * Hver kommando evalueres for seg selv via egne `kan...`-funksjoner.
  */
 fun Meldekortbehandling.finnGyldigeKommandoer(saksbehandler: Saksbehandler): List<SaksbehandlerBehandlingKommando> {
     return buildList {

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/MeldekortbehandlingGyldigeKommandoerEx.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/MeldekortbehandlingGyldigeKommandoerEx.kt
@@ -7,6 +7,7 @@ import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus.UNDER_BESLUTNING
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.avbryt.kanAvbryte
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.gjenoppta.kanGjenoppta
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.overta.kanOverta
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.settPåVent.kanSettePåVent
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.ta.kanTaMeldekortbehandling
 import no.nav.tiltakspenger.saksbehandling.saksbehandler.SaksbehandlerBehandlingKommando
@@ -36,7 +37,7 @@ private fun Meldekortbehandling.kanTildelSaksbehandler(saksbehandler: Saksbehand
 private fun Meldekortbehandling.kanOvertaSaksbehandler(saksbehandler: Saksbehandler): Boolean =
     status == UNDER_BEHANDLING &&
         this.saksbehandler != saksbehandler.navIdent &&
-        saksbehandler.erSaksbehandler()
+        kanOverta(saksbehandler).isRight()
 
 private fun Meldekortbehandling.kanLeggeTilbakeSaksbehandler(saksbehandler: Saksbehandler): Boolean =
     status == UNDER_BEHANDLING && this.saksbehandler == saksbehandler.navIdent
@@ -47,8 +48,7 @@ private fun Meldekortbehandling.kanTildelBeslutter(saksbehandler: Saksbehandler)
 private fun Meldekortbehandling.kanOvertaBeslutter(saksbehandler: Saksbehandler): Boolean =
     status == UNDER_BESLUTNING &&
         this.beslutter != saksbehandler.navIdent &&
-        saksbehandler.erBeslutter() &&
-        this.saksbehandler != saksbehandler.navIdent
+        kanOverta(saksbehandler).isRight()
 
 private fun Meldekortbehandling.kanLeggeTilbakeBeslutter(saksbehandler: Saksbehandler): Boolean =
     status == UNDER_BESLUTNING && this.beslutter == saksbehandler.navIdent

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/MeldekortbehandlingGyldigeKommandoerEx.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/MeldekortbehandlingGyldigeKommandoerEx.kt
@@ -5,6 +5,7 @@ import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus.KLAR_TIL_BESLUTNING
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus.UNDER_BEHANDLING
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus.UNDER_BESLUTNING
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.avbryt.kanAvbryte
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.gjenoppta.kanGjenoppta
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.ta.kanTaMeldekortbehandling
 import no.nav.tiltakspenger.saksbehandling.saksbehandler.SaksbehandlerBehandlingKommando
@@ -23,6 +24,7 @@ fun Meldekortbehandling.gyldigeKommandoer(saksbehandler: Saksbehandler): List<Sa
         if (kanOvertaBeslutter(saksbehandler)) add(SaksbehandlerBehandlingKommando.OvertaBeslutter)
         if (kanLeggeTilbakeBeslutter(saksbehandler)) add(SaksbehandlerBehandlingKommando.LeggTilbakeBeslutter)
         if (kanGjenoppta(saksbehandler).isRight()) add(SaksbehandlerBehandlingKommando.Gjenoppta)
+        if (kanAvbryte(saksbehandler).isRight()) add(SaksbehandlerBehandlingKommando.Avslutt)
     }
 }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/MeldekortbehandlingManuell.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/MeldekortbehandlingManuell.kt
@@ -29,8 +29,6 @@ import no.nav.tiltakspenger.saksbehandling.klage.domene.iverksett.IverksettOppre
 import no.nav.tiltakspenger.saksbehandling.klage.domene.iverksett.iverksettOmgjøring
 import no.nav.tiltakspenger.saksbehandling.klage.domene.iverksett.iverksettOpprettholdelse
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.iverksett.KanIkkeIverksetteMeldekortbehandling
-import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.overta.KunneIkkeOvertaMeldekortbehandling
-import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.overta.OvertaMeldekortbehandlingKommando
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.underkjenn.KanIkkeUnderkjenneMeldekortbehandling
 import no.nav.tiltakspenger.saksbehandling.oppfølgingsenhet.Navkontor
 import no.nav.tiltakspenger.saksbehandling.statistikk.Statistikkhendelser
@@ -225,39 +223,6 @@ data class MeldekortbehandlingManuell(
             ventestatus = ventestatus,
             klagebehandling = klagebehandling,
         ).right()
-    }
-
-    override fun overta(
-        kommando: OvertaMeldekortbehandlingKommando,
-        clock: Clock,
-    ): Either<KunneIkkeOvertaMeldekortbehandling, Meldekortbehandling> {
-        return when (this.status) {
-            MeldekortbehandlingStatus.KLAR_TIL_BEHANDLING -> throw IllegalStateException("Et manuelt behandlet meldekort kan ikke ha status KLAR_TIL_BEHANDLING")
-
-            MeldekortbehandlingStatus.AVBRUTT -> throw IllegalStateException("Et manuelt behandlet meldekort kan ikke ha status AVBRUTT")
-
-            MeldekortbehandlingStatus.UNDER_BEHANDLING -> throw IllegalStateException("Et utfylt meldekort kan ikke ha status UNDER_BEHANDLING")
-
-            MeldekortbehandlingStatus.KLAR_TIL_BESLUTNING -> KunneIkkeOvertaMeldekortbehandling.BehandlingenMåVæreUnderBeslutningForÅOverta.left()
-
-            MeldekortbehandlingStatus.UNDER_BESLUTNING -> {
-                krevBeslutterRolle(kommando.saksbehandler)
-                if (this.beslutter == null) {
-                    return KunneIkkeOvertaMeldekortbehandling.BehandlingenErIkkeKnyttetTilEnBeslutterForÅOverta.left()
-                }
-                if (this.saksbehandler == kommando.saksbehandler.navIdent) {
-                    return KunneIkkeOvertaMeldekortbehandling.SaksbehandlerOgBeslutterKanIkkeVæreDenSamme.left()
-                }
-                this.copy(
-                    beslutter = kommando.saksbehandler.navIdent,
-                    sistEndret = nå(clock),
-                ).right()
-            }
-
-            MeldekortbehandlingStatus.GODKJENT,
-            MeldekortbehandlingStatus.AUTOMATISK_BEHANDLET,
-            -> KunneIkkeOvertaMeldekortbehandling.BehandlingenKanIkkeVæreGodkjentEllerIkkeRett.left()
-        }
     }
 
     override fun leggTilbakeMeldekortbehandling(saksbehandler: Saksbehandler, clock: Clock): Meldekortbehandling {

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/MeldekortbehandlingManuell.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/MeldekortbehandlingManuell.kt
@@ -21,7 +21,6 @@ import no.nav.tiltakspenger.saksbehandling.felles.Attesteringsstatus
 import no.nav.tiltakspenger.saksbehandling.felles.Avbrutt
 import no.nav.tiltakspenger.saksbehandling.felles.Begrunnelse
 import no.nav.tiltakspenger.saksbehandling.felles.Ventestatus
-import no.nav.tiltakspenger.saksbehandling.felles.krevBeslutterRolle
 import no.nav.tiltakspenger.saksbehandling.klage.domene.Klagebehandling
 import no.nav.tiltakspenger.saksbehandling.klage.domene.Klagebehandlingsresultat
 import no.nav.tiltakspenger.saksbehandling.klage.domene.iverksett.IverksettOmgjøringKommando
@@ -223,32 +222,6 @@ data class MeldekortbehandlingManuell(
             ventestatus = ventestatus,
             klagebehandling = klagebehandling,
         ).right()
-    }
-
-    override fun leggTilbakeMeldekortbehandling(saksbehandler: Saksbehandler, clock: Clock): Meldekortbehandling {
-        return when (this.status) {
-            MeldekortbehandlingStatus.UNDER_BESLUTNING -> {
-                krevBeslutterRolle(saksbehandler)
-                require(this.beslutter == saksbehandler.navIdent)
-                this.copy(
-                    beslutter = null,
-                    status = MeldekortbehandlingStatus.KLAR_TIL_BESLUTNING,
-                    sistEndret = nå(clock),
-                )
-            }
-
-            MeldekortbehandlingStatus.UNDER_BEHANDLING,
-            MeldekortbehandlingStatus.KLAR_TIL_BESLUTNING,
-            MeldekortbehandlingStatus.GODKJENT,
-            MeldekortbehandlingStatus.AUTOMATISK_BEHANDLET,
-            MeldekortbehandlingStatus.AVBRUTT,
-            MeldekortbehandlingStatus.KLAR_TIL_BEHANDLING,
-            -> {
-                throw IllegalArgumentException(
-                    "Kan ikke legge tilbake meldekortbehandling når behandlingen har status ${this.status}. Utøvende saksbehandler: $saksbehandler. Saksbehandler på behandling: ${this.saksbehandler}",
-                )
-            }
-        }
     }
 
     override fun oppdaterSimulering(simulering: Simulering?): Meldekortbehandling {

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/MeldekortbehandlingUnderBehandling.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/MeldekortbehandlingUnderBehandling.kt
@@ -24,14 +24,10 @@ import no.nav.tiltakspenger.saksbehandling.klage.domene.KlagebehandlingId
 import no.nav.tiltakspenger.saksbehandling.klage.domene.hentKlagebehandling
 import no.nav.tiltakspenger.saksbehandling.klage.domene.leggTilbake.LeggTilbakeKlagebehandlingKommando
 import no.nav.tiltakspenger.saksbehandling.klage.domene.leggTilbake.leggTilbake
-import no.nav.tiltakspenger.saksbehandling.klage.domene.overta.OvertaKlagebehandlingKommando
-import no.nav.tiltakspenger.saksbehandling.klage.domene.overta.overta
 import no.nav.tiltakspenger.saksbehandling.klage.domene.tilTilknyttetBehandlingsstatus
 import no.nav.tiltakspenger.saksbehandling.klage.domene.vurder.oppdaterBehandlingId
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.oppdater.KanIkkeOppdatereMeldekortbehandling
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.oppdater.OppdaterMeldekortbehandlingKommando
-import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.overta.KunneIkkeOvertaMeldekortbehandling
-import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.overta.OvertaMeldekortbehandlingKommando
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.tilBeslutter.KanIkkeSendeMeldekortbehandlingTilBeslutter
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.tilBeslutter.SendMeldekortbehandlingTilBeslutterKommando
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.KanIkkeOppretteMeldekortbehandling
@@ -179,43 +175,6 @@ data class MeldekortUnderBehandling(
 
     fun erKlarTilUtfylling(clock: Clock): Boolean {
         return !LocalDate.now(clock).isBefore(periode.fraOgMed)
-    }
-
-    override fun overta(
-        kommando: OvertaMeldekortbehandlingKommando,
-        clock: Clock,
-    ): Either<KunneIkkeOvertaMeldekortbehandling, Meldekortbehandling> {
-        return when (this.status) {
-            MeldekortbehandlingStatus.UNDER_BEHANDLING -> {
-                krevSaksbehandlerRolle(kommando.saksbehandler)
-                if (this.saksbehandler == null) {
-                    return KunneIkkeOvertaMeldekortbehandling.BehandlingenErIkkeKnyttetTilEnSaksbehandlerForÅOverta.left()
-                }
-                this.copy(
-                    saksbehandler = kommando.saksbehandler.navIdent,
-                    sistEndret = nå(clock),
-                    klagebehandling = klagebehandling?.overta(
-                        kommando = OvertaKlagebehandlingKommando(
-                            sakId = sakId,
-                            klagebehandlingId = klagebehandling.id,
-                            overtarFra = kommando.overtarFra,
-                            saksbehandler = kommando.saksbehandler,
-                            correlationId = kommando.correlationId,
-                        ),
-                        tilknyttetBehandlingsstatus = this.status.tilTilknyttetBehandlingsstatus(),
-                        clock = clock,
-                    )?.getOrThrow()?.first,
-                ).right()
-            }
-
-            MeldekortbehandlingStatus.KLAR_TIL_BESLUTNING,
-            MeldekortbehandlingStatus.UNDER_BESLUTNING,
-            MeldekortbehandlingStatus.GODKJENT,
-            MeldekortbehandlingStatus.AUTOMATISK_BEHANDLET,
-            MeldekortbehandlingStatus.AVBRUTT,
-            MeldekortbehandlingStatus.KLAR_TIL_BEHANDLING,
-            -> throw IllegalStateException("Kan ikke overta meldekortbehandling med status ${this.status}")
-        }
     }
 
     override fun leggTilbakeMeldekortbehandling(saksbehandler: Saksbehandler, clock: Clock): Meldekortbehandling {

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/MeldekortbehandlingUnderBehandling.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/MeldekortbehandlingUnderBehandling.kt
@@ -17,14 +17,9 @@ import no.nav.tiltakspenger.saksbehandling.felles.Attesteringer
 import no.nav.tiltakspenger.saksbehandling.felles.Avbrutt
 import no.nav.tiltakspenger.saksbehandling.felles.Begrunnelse
 import no.nav.tiltakspenger.saksbehandling.felles.Ventestatus
-import no.nav.tiltakspenger.saksbehandling.felles.getOrThrow
-import no.nav.tiltakspenger.saksbehandling.felles.krevSaksbehandlerRolle
 import no.nav.tiltakspenger.saksbehandling.klage.domene.Klagebehandling
 import no.nav.tiltakspenger.saksbehandling.klage.domene.KlagebehandlingId
 import no.nav.tiltakspenger.saksbehandling.klage.domene.hentKlagebehandling
-import no.nav.tiltakspenger.saksbehandling.klage.domene.leggTilbake.LeggTilbakeKlagebehandlingKommando
-import no.nav.tiltakspenger.saksbehandling.klage.domene.leggTilbake.leggTilbake
-import no.nav.tiltakspenger.saksbehandling.klage.domene.tilTilknyttetBehandlingsstatus
 import no.nav.tiltakspenger.saksbehandling.klage.domene.vurder.oppdaterBehandlingId
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.oppdater.KanIkkeOppdatereMeldekortbehandling
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.oppdater.OppdaterMeldekortbehandlingKommando
@@ -175,43 +170,6 @@ data class MeldekortUnderBehandling(
 
     fun erKlarTilUtfylling(clock: Clock): Boolean {
         return !LocalDate.now(clock).isBefore(periode.fraOgMed)
-    }
-
-    override fun leggTilbakeMeldekortbehandling(saksbehandler: Saksbehandler, clock: Clock): Meldekortbehandling {
-        return when (this.status) {
-            MeldekortbehandlingStatus.UNDER_BEHANDLING -> {
-                krevSaksbehandlerRolle(saksbehandler)
-                require(this.saksbehandler == saksbehandler.navIdent)
-                this.copy(
-                    saksbehandler = null,
-                    status = MeldekortbehandlingStatus.KLAR_TIL_BEHANDLING,
-                    sistEndret = nå(clock),
-                    klagebehandling = klagebehandling?.let { klage ->
-                        klage.leggTilbake(
-                            kommando = LeggTilbakeKlagebehandlingKommando(
-                                sakId = sakId,
-                                klagebehandlingId = klage.id,
-                                saksbehandler = saksbehandler,
-                            ),
-                            tilknyttetBehandlingsstatus = this.status.tilTilknyttetBehandlingsstatus(),
-                            clock = clock,
-                        ).getOrThrow().first
-                    },
-                )
-            }
-
-            MeldekortbehandlingStatus.KLAR_TIL_BEHANDLING,
-            MeldekortbehandlingStatus.KLAR_TIL_BESLUTNING,
-            MeldekortbehandlingStatus.UNDER_BESLUTNING,
-            MeldekortbehandlingStatus.GODKJENT,
-            MeldekortbehandlingStatus.AUTOMATISK_BEHANDLET,
-            MeldekortbehandlingStatus.AVBRUTT,
-            -> {
-                throw IllegalArgumentException(
-                    "Kan ikke ta meldekortbehandling når behandlingen har status ${this.status}. Utøvende saksbehandler: $saksbehandler. Saksbehandler på behandling: ${this.saksbehandler}",
-                )
-            }
-        }
     }
 
     override fun oppdaterSimulering(simulering: Simulering?): Meldekortbehandling {

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/avbryt/MeldekortbehandlingAvbrytEx.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/avbryt/MeldekortbehandlingAvbrytEx.kt
@@ -5,6 +5,7 @@ import arrow.core.left
 import arrow.core.right
 import no.nav.tiltakspenger.libs.common.NonBlankString
 import no.nav.tiltakspenger.libs.common.NonBlankString.Companion.toNonBlankString
+import no.nav.tiltakspenger.libs.common.Saksbehandler
 import no.nav.tiltakspenger.saksbehandling.felles.Avbrutt
 import no.nav.tiltakspenger.saksbehandling.infra.setup.AUTOMATISK_SAKSBEHANDLER_ID
 import no.nav.tiltakspenger.saksbehandling.klage.domene.vurder.fjernBehandlingId
@@ -18,15 +19,9 @@ fun Meldekortbehandling.avbryt(
     kommando: AvbrytMeldekortbehandlingKommando,
     tidspunkt: LocalDateTime,
 ): Either<KanIkkeAvbryteMeldekortbehandling, Meldekortbehandling> {
-    if (this.status != MeldekortbehandlingStatus.UNDER_BEHANDLING) {
-        return KanIkkeAvbryteMeldekortbehandling.MåVæreUnderBehandling.left()
-    }
+    kanAvbryte(kommando.saksbehandler).onLeft { return it.left() }
 
     val avbruttAv = kommando.saksbehandler.navIdent
-
-    if (this.saksbehandler != avbruttAv) {
-        return KanIkkeAvbryteMeldekortbehandling.MåVæreSaksbehandlerForMeldekortet.left()
-    }
 
     val avbruttMeldekort = this.avbryt(
         saksbehandlerIdent = avbruttAv,
@@ -44,6 +39,27 @@ fun Meldekortbehandling.avbryt(
     } ?: avbruttMeldekort
 
     return oppdatertMeldekort.right()
+}
+
+/**
+ * Avgjør om [saksbehandler] kan avbryte meldekortbehandlingen.
+ *
+ * Betingelsene speiler hva [avbryt] faktisk håndterer:
+ *  - behandlingen må ha status [MeldekortbehandlingStatus.UNDER_BEHANDLING]
+ *  - [saksbehandler] må være saksbehandleren som er tildelt behandlingen
+ */
+fun Meldekortbehandling.kanAvbryte(
+    saksbehandler: Saksbehandler,
+): Either<KanIkkeAvbryteMeldekortbehandling, Unit> {
+    if (this.status != MeldekortbehandlingStatus.UNDER_BEHANDLING) {
+        return KanIkkeAvbryteMeldekortbehandling.MåVæreUnderBehandling.left()
+    }
+
+    if (this.saksbehandler != saksbehandler.navIdent) {
+        return KanIkkeAvbryteMeldekortbehandling.MåVæreSaksbehandlerForMeldekortet.left()
+    }
+
+    return Unit.right()
 }
 
 /** Avbryter en meldekortbehandling fordi det ikke lenger er rett til tiltakspenger i perioden. Dette er en automatisk handling. */

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/gjenoppta/KanIkkeGjenopptaMeldekortbehandling.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/gjenoppta/KanIkkeGjenopptaMeldekortbehandling.kt
@@ -1,0 +1,28 @@
+package no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.gjenoppta
+
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus
+
+/**
+ * Mulige grunner til at en meldekortbehandling ikke kan gjenopptas.
+ *
+ * Se `Meldekortbehandling.kanGjenoppta`.
+ */
+sealed interface KanIkkeGjenopptaMeldekortbehandling {
+    /** Behandlingen er ikke satt på vent, og kan dermed ikke gjenopptas. */
+    data object BehandlingenErIkkePåVent : KanIkkeGjenopptaMeldekortbehandling
+
+    /** Utøvende bruker mangler saksbehandlerrolle. */
+    data object MåVæreSaksbehandler : KanIkkeGjenopptaMeldekortbehandling
+
+    /** Behandlingen kan kun gjenopptas av saksbehandleren som er tildelt behandlingen. */
+    data object MåVæreSaksbehandlerSomEierBehandlingen : KanIkkeGjenopptaMeldekortbehandling
+
+    /** Utøvende bruker mangler beslutterrolle. */
+    data object MåVæreBeslutter : KanIkkeGjenopptaMeldekortbehandling
+
+    /** Beslutteren kan ikke være den samme som saksbehandleren på behandlingen. */
+    data object BeslutterKanIkkeVæreSammeSomSaksbehandler : KanIkkeGjenopptaMeldekortbehandling
+
+    /** Behandlingen er i en status som ikke kan gjenopptas. */
+    data class UgyldigStatus(val status: MeldekortbehandlingStatus) : KanIkkeGjenopptaMeldekortbehandling
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/gjenoppta/MeldekortbehandlingGjenopptaEx.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/gjenoppta/MeldekortbehandlingGjenopptaEx.kt
@@ -1,9 +1,11 @@
 package no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.gjenoppta
 
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import no.nav.tiltakspenger.libs.common.Saksbehandler
 import no.nav.tiltakspenger.libs.common.nå
 import no.nav.tiltakspenger.saksbehandling.felles.getOrThrow
-import no.nav.tiltakspenger.saksbehandling.felles.krevBeslutterRolle
-import no.nav.tiltakspenger.saksbehandling.felles.krevSaksbehandlerRolle
 import no.nav.tiltakspenger.saksbehandling.klage.domene.gjenoppta.GjenopptaKlagebehandlingKommando
 import no.nav.tiltakspenger.saksbehandling.klage.domene.gjenoppta.gjenopptaKlagebehandling
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortUnderBehandling
@@ -21,8 +23,9 @@ import java.time.Clock
 fun Meldekortbehandling.gjenoppta(
     kommando: GjenopptaMeldekortbehandlingKommando,
     clock: Clock,
-): Meldekortbehandling {
-    require(ventestatus.erSattPåVent) { "Meldekortbehandling med id ${this.id} er ikke satt på vent" }
+): Either<KanIkkeGjenopptaMeldekortbehandling, Meldekortbehandling> {
+    kanGjenoppta(kommando.saksbehandler).onLeft { return it.left() }
+
     val gjenopptattAv = kommando.saksbehandler
     val nå = nå(clock)
     val oppdatertVentestatus = ventestatus.gjenoppta(
@@ -30,10 +33,8 @@ fun Meldekortbehandling.gjenoppta(
         endretAv = gjenopptattAv.navIdent,
         status = status.toString(),
     )
-
     return when (status) {
         KLAR_TIL_BEHANDLING -> {
-            krevSaksbehandlerRolle(gjenopptattAv)
             require(this is MeldekortUnderBehandling) { "Meldekortbehandling med status $status må være MeldekortUnderBehandling" }
             this.copy(
                 saksbehandler = gjenopptattAv.navIdent,
@@ -51,15 +52,11 @@ fun Meldekortbehandling.gjenoppta(
                         clock = clock,
                     ).getOrThrow().first
                 },
-            )
+            ).right()
         }
 
         UNDER_BEHANDLING -> {
-            krevSaksbehandlerRolle(gjenopptattAv)
             require(this is MeldekortUnderBehandling) { "Meldekortbehandling med status $status må være MeldekortUnderBehandling" }
-            require(this.saksbehandler == gjenopptattAv.navIdent) {
-                "Du må være saksbehandler på meldekortbehandlingen for å kunne gjenoppta den."
-            }
             this.copy(
                 ventestatus = oppdatertVentestatus,
                 sistEndret = nå,
@@ -74,15 +71,11 @@ fun Meldekortbehandling.gjenoppta(
                         clock = clock,
                     ).getOrThrow().first
                 },
-            )
+            ).right()
         }
 
         KLAR_TIL_BESLUTNING -> {
-            krevBeslutterRolle(gjenopptattAv)
             require(this is MeldekortbehandlingManuell) { "Meldekortbehandling med status $status må være MeldekortbehandlingManuell" }
-            require(this.saksbehandler != gjenopptattAv.navIdent) {
-                "Beslutter (${gjenopptattAv.navIdent}) kan ikke være den samme som saksbehandleren (${this.saksbehandler})"
-            }
             this.copy(
                 beslutter = gjenopptattAv.navIdent,
                 status = UNDER_BESLUTNING,
@@ -94,13 +87,65 @@ fun Meldekortbehandling.gjenoppta(
                     endretAv = kommando.saksbehandler.navIdent,
                     clock = clock,
                 )?.getOrThrow()?.first,
-            )
+            ).right()
         }
 
         UNDER_BESLUTNING,
         GODKJENT,
         AUTOMATISK_BEHANDLET,
         AVBRUTT,
-        -> throw IllegalStateException("Kan ikke gjenoppta meldekortbehandling som har status ${status.name}")
+        -> KanIkkeGjenopptaMeldekortbehandling.UgyldigStatus(status).left()
+    }
+}
+
+/**
+ * Avgjør om meldekortbehandlingen kan gjenopptas av [saksbehandler].
+ *
+ * Betingelsene speiler hvilke tilstander [gjenoppta] faktisk håndterer:
+ *  - behandlingen må være satt på vent
+ *  - [KLAR_TIL_BEHANDLING]: kan gjenopptas av en saksbehandler
+ *  - [UNDER_BEHANDLING]: kan gjenopptas av saksbehandleren som er tildelt behandlingen
+ *  - [KLAR_TIL_BESLUTNING]: kan gjenopptas av en beslutter som ikke er saksbehandleren på behandlingen
+ */
+fun Meldekortbehandling.kanGjenoppta(
+    saksbehandler: Saksbehandler,
+): Either<KanIkkeGjenopptaMeldekortbehandling, Unit> {
+    if (!ventestatus.erSattPåVent) {
+        return KanIkkeGjenopptaMeldekortbehandling.BehandlingenErIkkePåVent.left()
+    }
+    return when (status) {
+        KLAR_TIL_BEHANDLING -> {
+            if (!saksbehandler.erSaksbehandler()) {
+                KanIkkeGjenopptaMeldekortbehandling.MåVæreSaksbehandler.left()
+            } else {
+                Unit.right()
+            }
+        }
+
+        UNDER_BEHANDLING -> {
+            if (!saksbehandler.erSaksbehandler()) {
+                KanIkkeGjenopptaMeldekortbehandling.MåVæreSaksbehandler.left()
+            } else if (this.saksbehandler != saksbehandler.navIdent) {
+                KanIkkeGjenopptaMeldekortbehandling.MåVæreSaksbehandlerSomEierBehandlingen.left()
+            } else {
+                Unit.right()
+            }
+        }
+
+        KLAR_TIL_BESLUTNING -> {
+            if (!saksbehandler.erBeslutter()) {
+                KanIkkeGjenopptaMeldekortbehandling.MåVæreBeslutter.left()
+            } else if (this.saksbehandler == saksbehandler.navIdent) {
+                KanIkkeGjenopptaMeldekortbehandling.BeslutterKanIkkeVæreSammeSomSaksbehandler.left()
+            } else {
+                Unit.right()
+            }
+        }
+
+        UNDER_BESLUTNING,
+        GODKJENT,
+        AUTOMATISK_BEHANDLET,
+        AVBRUTT,
+        -> KanIkkeGjenopptaMeldekortbehandling.UgyldigStatus(status).left()
     }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/leggTilbake/KanIkkeLeggeTilbakeMeldekortbehandling.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/leggTilbake/KanIkkeLeggeTilbakeMeldekortbehandling.kt
@@ -1,0 +1,25 @@
+package no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.leggTilbake
+
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus
+
+/**
+ * Mulige grunner til at en meldekortbehandling ikke kan legges tilbake.
+ *
+ * Se `Meldekortbehandling.kanLeggeTilbake`.
+ */
+sealed interface KanIkkeLeggeTilbakeMeldekortbehandling {
+    /** Utøvende bruker mangler saksbehandlerrolle. */
+    data object MåVæreSaksbehandler : KanIkkeLeggeTilbakeMeldekortbehandling
+
+    /** Behandlingen kan kun legges tilbake av saksbehandleren som er tildelt behandlingen. */
+    data object MåVæreSaksbehandlerForMeldekortet : KanIkkeLeggeTilbakeMeldekortbehandling
+
+    /** Utøvende bruker mangler beslutterrolle. */
+    data object MåVæreBeslutter : KanIkkeLeggeTilbakeMeldekortbehandling
+
+    /** Behandlingen kan kun legges tilbake av beslutteren som er tildelt behandlingen. */
+    data object MåVæreBeslutterForMeldekortet : KanIkkeLeggeTilbakeMeldekortbehandling
+
+    /** Behandlingen er i en status som ikke kan legges tilbake. */
+    data class UgyldigStatus(val status: MeldekortbehandlingStatus) : KanIkkeLeggeTilbakeMeldekortbehandling
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/leggTilbake/MeldekortbehandlingLeggTilbakeEx.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/leggTilbake/MeldekortbehandlingLeggTilbakeEx.kt
@@ -1,0 +1,112 @@
+package no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.leggTilbake
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import no.nav.tiltakspenger.libs.common.Saksbehandler
+import no.nav.tiltakspenger.libs.common.nå
+import no.nav.tiltakspenger.saksbehandling.felles.getOrThrow
+import no.nav.tiltakspenger.saksbehandling.klage.domene.leggTilbake.LeggTilbakeKlagebehandlingKommando
+import no.nav.tiltakspenger.saksbehandling.klage.domene.leggTilbake.leggTilbake
+import no.nav.tiltakspenger.saksbehandling.klage.domene.tilTilknyttetBehandlingsstatus
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortUnderBehandling
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.Meldekortbehandling
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingManuell
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus.AUTOMATISK_BEHANDLET
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus.AVBRUTT
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus.GODKJENT
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus.KLAR_TIL_BEHANDLING
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus.KLAR_TIL_BESLUTNING
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus.UNDER_BEHANDLING
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus.UNDER_BESLUTNING
+import java.time.Clock
+
+/**
+ * Legger tilbake meldekortbehandlingen for [saksbehandler]:
+ *  - [UNDER_BEHANDLING] -> nullstiller saksbehandler ([KLAR_TIL_BEHANDLING]).
+ *  - [UNDER_BESLUTNING] -> nullstiller beslutter ([KLAR_TIL_BESLUTNING]).
+ */
+fun Meldekortbehandling.leggTilbakeMeldekortbehandling(
+    saksbehandler: Saksbehandler,
+    clock: Clock,
+): Either<KanIkkeLeggeTilbakeMeldekortbehandling, Meldekortbehandling> {
+    kanLeggeTilbake(saksbehandler).onLeft { return it.left() }
+
+    return when (status) {
+        UNDER_BEHANDLING -> {
+            require(this is MeldekortUnderBehandling) { "Meldekortbehandling med status $status må være MeldekortUnderBehandling" }
+            this.copy(
+                saksbehandler = null,
+                status = KLAR_TIL_BEHANDLING,
+                sistEndret = nå(clock),
+                klagebehandling = klagebehandling?.let { klage ->
+                    klage.leggTilbake(
+                        kommando = LeggTilbakeKlagebehandlingKommando(
+                            sakId = sakId,
+                            klagebehandlingId = klage.id,
+                            saksbehandler = saksbehandler,
+                        ),
+                        tilknyttetBehandlingsstatus = status.tilTilknyttetBehandlingsstatus(),
+                        clock = clock,
+                    ).getOrThrow().first
+                },
+            ).right()
+        }
+
+        UNDER_BESLUTNING -> {
+            require(this is MeldekortbehandlingManuell) { "Meldekortbehandling med status $status må være MeldekortbehandlingManuell" }
+            this.copy(
+                beslutter = null,
+                status = KLAR_TIL_BESLUTNING,
+                sistEndret = nå(clock),
+            ).right()
+        }
+
+        KLAR_TIL_BEHANDLING,
+        KLAR_TIL_BESLUTNING,
+        GODKJENT,
+        AUTOMATISK_BEHANDLET,
+        AVBRUTT,
+        -> throw IllegalStateException("Skal ha blitt fanget opp av kanLeggeTilbake. Kan ikke legge tilbake meldekortbehandling med status $status")
+    }
+}
+
+/**
+ * Avgjør om [saksbehandler] kan legge tilbake meldekortbehandlingen.
+ *
+ * Betingelsene speiler hvilke tilstander [leggTilbakeMeldekortbehandling] faktisk håndterer:
+ *  - [UNDER_BEHANDLING]: kan legges tilbake av saksbehandleren som er tildelt behandlingen.
+ *  - [UNDER_BESLUTNING]: kan legges tilbake av beslutteren som er tildelt behandlingen.
+ */
+fun Meldekortbehandling.kanLeggeTilbake(
+    saksbehandler: Saksbehandler,
+): Either<KanIkkeLeggeTilbakeMeldekortbehandling, Unit> {
+    return when (status) {
+        UNDER_BEHANDLING -> {
+            if (!saksbehandler.erSaksbehandler()) {
+                KanIkkeLeggeTilbakeMeldekortbehandling.MåVæreSaksbehandler.left()
+            } else if (this.saksbehandler != saksbehandler.navIdent) {
+                KanIkkeLeggeTilbakeMeldekortbehandling.MåVæreSaksbehandlerForMeldekortet.left()
+            } else {
+                Unit.right()
+            }
+        }
+
+        UNDER_BESLUTNING -> {
+            if (!saksbehandler.erBeslutter()) {
+                KanIkkeLeggeTilbakeMeldekortbehandling.MåVæreBeslutter.left()
+            } else if (this.beslutter != saksbehandler.navIdent) {
+                KanIkkeLeggeTilbakeMeldekortbehandling.MåVæreBeslutterForMeldekortet.left()
+            } else {
+                Unit.right()
+            }
+        }
+
+        KLAR_TIL_BEHANDLING,
+        KLAR_TIL_BESLUTNING,
+        GODKJENT,
+        AUTOMATISK_BEHANDLET,
+        AVBRUTT,
+        -> KanIkkeLeggeTilbakeMeldekortbehandling.UgyldigStatus(status).left()
+    }
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/overta/KunneIkkeOvertaMeldekortbehandling.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/overta/KunneIkkeOvertaMeldekortbehandling.kt
@@ -1,5 +1,7 @@
 package no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.overta
 
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus
+
 sealed interface KunneIkkeOvertaMeldekortbehandling {
     data object BehandlingenKanIkkeVæreGodkjentEllerIkkeRett : KunneIkkeOvertaMeldekortbehandling
 
@@ -12,4 +14,10 @@ sealed interface KunneIkkeOvertaMeldekortbehandling {
     data object SaksbehandlerOgBeslutterKanIkkeVæreDenSamme : KunneIkkeOvertaMeldekortbehandling
 
     data object KanIkkeOvertaAutomatiskBehandling : KunneIkkeOvertaMeldekortbehandling
+
+    data object MåVæreSaksbehandler : KunneIkkeOvertaMeldekortbehandling
+
+    data object MåVæreBeslutter : KunneIkkeOvertaMeldekortbehandling
+
+    data class UgyldigStatus(val status: MeldekortbehandlingStatus) : KunneIkkeOvertaMeldekortbehandling
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/overta/MeldekortbehandlingOvertaEx.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/overta/MeldekortbehandlingOvertaEx.kt
@@ -1,0 +1,117 @@
+package no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.overta
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import no.nav.tiltakspenger.libs.common.Saksbehandler
+import no.nav.tiltakspenger.libs.common.nå
+import no.nav.tiltakspenger.saksbehandling.felles.getOrThrow
+import no.nav.tiltakspenger.saksbehandling.klage.domene.overta.OvertaKlagebehandlingKommando
+import no.nav.tiltakspenger.saksbehandling.klage.domene.overta.overta
+import no.nav.tiltakspenger.saksbehandling.klage.domene.tilTilknyttetBehandlingsstatus
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortUnderBehandling
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.Meldekortbehandling
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingManuell
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus.AUTOMATISK_BEHANDLET
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus.AVBRUTT
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus.GODKJENT
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus.KLAR_TIL_BEHANDLING
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus.KLAR_TIL_BESLUTNING
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus.UNDER_BEHANDLING
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus.UNDER_BESLUTNING
+import java.time.Clock
+
+/**
+ * Overtar meldekortbehandlingen for [OvertaMeldekortbehandlingKommando.saksbehandler]:
+ *  - [UNDER_BEHANDLING] -> overtar som saksbehandler.
+ *  - [UNDER_BESLUTNING] -> overtar som beslutter.
+ */
+fun Meldekortbehandling.overta(
+    kommando: OvertaMeldekortbehandlingKommando,
+    clock: Clock,
+): Either<KunneIkkeOvertaMeldekortbehandling, Meldekortbehandling> {
+    kanOverta(kommando.saksbehandler).onLeft { return it.left() }
+
+    return when (status) {
+        UNDER_BEHANDLING -> {
+            require(this is MeldekortUnderBehandling) { "Meldekortbehandling med status $status må være MeldekortUnderBehandling" }
+            this.copy(
+                saksbehandler = kommando.saksbehandler.navIdent,
+                sistEndret = nå(clock),
+                klagebehandling = klagebehandling?.let { klage ->
+                    klage.overta(
+                        kommando = OvertaKlagebehandlingKommando(
+                            sakId = sakId,
+                            klagebehandlingId = klage.id,
+                            overtarFra = kommando.overtarFra,
+                            saksbehandler = kommando.saksbehandler,
+                            correlationId = kommando.correlationId,
+                        ),
+                        tilknyttetBehandlingsstatus = status.tilTilknyttetBehandlingsstatus(),
+                        clock = clock,
+                    ).getOrThrow().first
+                },
+            ).right()
+        }
+
+        UNDER_BESLUTNING -> {
+            require(this is MeldekortbehandlingManuell) { "Meldekortbehandling med status $status må være MeldekortbehandlingManuell" }
+            this.copy(
+                beslutter = kommando.saksbehandler.navIdent,
+                sistEndret = nå(clock),
+            ).right()
+        }
+
+        KLAR_TIL_BEHANDLING,
+        KLAR_TIL_BESLUTNING,
+        GODKJENT,
+        AUTOMATISK_BEHANDLET,
+        AVBRUTT,
+        -> throw IllegalStateException("Skal ha blitt fanget opp av kanOverta. Kan ikke overta meldekortbehandling med status $status")
+    }
+}
+
+/**
+ * Avgjør om [saksbehandler] kan overta meldekortbehandlingen.
+ *
+ * Betingelsene speiler hvilke tilstander [overta] faktisk håndterer:
+ *  - [UNDER_BEHANDLING]: kan overtas av en annen saksbehandler enn den som er tildelt, gitt at behandlingen har en saksbehandler.
+ *  - [UNDER_BESLUTNING]: kan overtas av en annen beslutter enn saksbehandleren, gitt at behandlingen har en beslutter.
+ */
+fun Meldekortbehandling.kanOverta(
+    saksbehandler: Saksbehandler,
+): Either<KunneIkkeOvertaMeldekortbehandling, Unit> {
+    return when (status) {
+        UNDER_BEHANDLING -> {
+            if (!saksbehandler.erSaksbehandler()) {
+                KunneIkkeOvertaMeldekortbehandling.MåVæreSaksbehandler.left()
+            } else if (this.saksbehandler == null) {
+                KunneIkkeOvertaMeldekortbehandling.BehandlingenErIkkeKnyttetTilEnSaksbehandlerForÅOverta.left()
+            } else {
+                Unit.right()
+            }
+        }
+
+        UNDER_BESLUTNING -> {
+            if (!saksbehandler.erBeslutter()) {
+                KunneIkkeOvertaMeldekortbehandling.MåVæreBeslutter.left()
+            } else if (this.beslutter == null) {
+                KunneIkkeOvertaMeldekortbehandling.BehandlingenErIkkeKnyttetTilEnBeslutterForÅOverta.left()
+            } else if (this.saksbehandler == saksbehandler.navIdent) {
+                KunneIkkeOvertaMeldekortbehandling.SaksbehandlerOgBeslutterKanIkkeVæreDenSamme.left()
+            } else {
+                Unit.right()
+            }
+        }
+
+        KLAR_TIL_BESLUTNING -> KunneIkkeOvertaMeldekortbehandling.BehandlingenMåVæreUnderBeslutningForÅOverta.left()
+
+        GODKJENT -> KunneIkkeOvertaMeldekortbehandling.BehandlingenKanIkkeVæreGodkjentEllerIkkeRett.left()
+
+        AUTOMATISK_BEHANDLET -> KunneIkkeOvertaMeldekortbehandling.KanIkkeOvertaAutomatiskBehandling.left()
+
+        KLAR_TIL_BEHANDLING,
+        AVBRUTT,
+        -> KunneIkkeOvertaMeldekortbehandling.UgyldigStatus(status).left()
+    }
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/settPåVent/KanIkkeSetteMeldekortbehandlingPåVent.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/settPåVent/KanIkkeSetteMeldekortbehandlingPåVent.kt
@@ -1,0 +1,28 @@
+package no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.settPåVent
+
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus
+
+/**
+ * Mulige grunner til at en meldekortbehandling ikke kan settes på vent.
+ *
+ * Se `Meldekortbehandling.kanSettePåVent`.
+ */
+sealed interface KanIkkeSetteMeldekortbehandlingPåVent {
+    /** Behandlingen er allerede satt på vent. */
+    data object BehandlingenErAlleredePåVent : KanIkkeSetteMeldekortbehandlingPåVent
+
+    /** Utøvende bruker mangler saksbehandlerrolle. */
+    data object MåVæreSaksbehandler : KanIkkeSetteMeldekortbehandlingPåVent
+
+    /** Behandlingen kan kun settes på vent av saksbehandleren som er tildelt behandlingen. */
+    data object MåVæreSaksbehandlerForMeldekortet : KanIkkeSetteMeldekortbehandlingPåVent
+
+    /** Utøvende bruker mangler beslutterrolle. */
+    data object MåVæreBeslutter : KanIkkeSetteMeldekortbehandlingPåVent
+
+    /** Behandlingen kan kun settes på vent av beslutteren som er tildelt behandlingen. */
+    data object MåVæreBeslutterForMeldekortet : KanIkkeSetteMeldekortbehandlingPåVent
+
+    /** Behandlingen er i en status som ikke kan settes på vent. */
+    data class UgyldigStatus(val status: MeldekortbehandlingStatus) : KanIkkeSetteMeldekortbehandlingPåVent
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/settPåVent/MeldekortbehandlingSettPåVentEx.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/settPåVent/MeldekortbehandlingSettPåVentEx.kt
@@ -1,9 +1,11 @@
 package no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.settPåVent
 
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import no.nav.tiltakspenger.libs.common.Saksbehandler
 import no.nav.tiltakspenger.libs.common.nå
 import no.nav.tiltakspenger.saksbehandling.felles.getOrThrow
-import no.nav.tiltakspenger.saksbehandling.felles.krevBeslutterRolle
-import no.nav.tiltakspenger.saksbehandling.felles.krevSaksbehandlerRolle
 import no.nav.tiltakspenger.saksbehandling.klage.domene.settPåVent.SettKlagebehandlingPåVentKommando
 import no.nav.tiltakspenger.saksbehandling.klage.domene.settPåVent.settPåVent
 import no.nav.tiltakspenger.saksbehandling.klage.domene.settPåVent.settPåVentOgNullstillSaksbehandler
@@ -22,14 +24,13 @@ import java.time.Clock
 fun Meldekortbehandling.settPåVent(
     kommando: SettMeldekortbehandlingPåVentKommando,
     clock: Clock,
-): Meldekortbehandling {
-    require(!ventestatus.erSattPåVent) { "Meldekortbehandling med id ${this.id} er allerede satt på vent" }
+): Either<KanIkkeSetteMeldekortbehandlingPåVent, Meldekortbehandling> {
+    kanSettePåVent(kommando.saksbehandler).onLeft { return it.left() }
+
     val endretAv = kommando.saksbehandler
 
     return when (status) {
         UNDER_BEHANDLING -> {
-            krevSaksbehandlerRolle(endretAv)
-            require(this.saksbehandler == endretAv.navIdent) { "Du må være saksbehandler på meldekortbehandlingen for å kunne sette den på vent." }
             require(this is MeldekortUnderBehandling) { "Meldekortbehandling med status $status må være MeldekortUnderBehandling" }
 
             val tidspunktSattPåVent = nå(clock)
@@ -57,12 +58,10 @@ fun Meldekortbehandling.settPåVent(
                         sjekkSaksbehandler = true,
                     ).getOrThrow().first
                 },
-            )
+            ).right()
         }
 
         UNDER_BESLUTNING -> {
-            krevBeslutterRolle(endretAv)
-            require(this.beslutter == endretAv.navIdent) { "Du må være beslutter på meldekortbehandlingen for å kunne sette den på vent." }
             require(this is MeldekortbehandlingManuell) { "Meldekortbehandling med status $status må være MeldekortbehandlingManuell" }
 
             val tidspunktSattPåVent = nå(clock)
@@ -90,7 +89,7 @@ fun Meldekortbehandling.settPåVent(
                         sjekkSaksbehandler = false,
                     ).getOrThrow().first
                 },
-            )
+            ).right()
         }
 
         KLAR_TIL_BEHANDLING,
@@ -98,6 +97,51 @@ fun Meldekortbehandling.settPåVent(
         GODKJENT,
         AUTOMATISK_BEHANDLET,
         AVBRUTT,
-        -> throw IllegalStateException("Kan ikke sette meldekortbehandling på vent som har status ${status.name}")
+        -> KanIkkeSetteMeldekortbehandlingPåVent.UgyldigStatus(status).left()
+    }
+}
+
+/**
+ * Avgjør om [saksbehandler] kan sette meldekortbehandlingen på vent.
+ *
+ * Betingelsene speiler hvilke tilstander [settPåVent] faktisk håndterer:
+ *  - behandlingen kan ikke allerede være satt på vent
+ *  - [UNDER_BEHANDLING]: kan settes på vent av saksbehandleren som er tildelt behandlingen
+ *  - [UNDER_BESLUTNING]: kan settes på vent av beslutteren som er tildelt behandlingen
+ */
+fun Meldekortbehandling.kanSettePåVent(
+    saksbehandler: Saksbehandler,
+): Either<KanIkkeSetteMeldekortbehandlingPåVent, Unit> {
+    if (ventestatus.erSattPåVent) {
+        return KanIkkeSetteMeldekortbehandlingPåVent.BehandlingenErAlleredePåVent.left()
+    }
+
+    return when (status) {
+        UNDER_BEHANDLING -> {
+            if (!saksbehandler.erSaksbehandler()) {
+                KanIkkeSetteMeldekortbehandlingPåVent.MåVæreSaksbehandler.left()
+            } else if (this.saksbehandler != saksbehandler.navIdent) {
+                KanIkkeSetteMeldekortbehandlingPåVent.MåVæreSaksbehandlerForMeldekortet.left()
+            } else {
+                Unit.right()
+            }
+        }
+
+        UNDER_BESLUTNING -> {
+            if (!saksbehandler.erBeslutter()) {
+                KanIkkeSetteMeldekortbehandlingPåVent.MåVæreBeslutter.left()
+            } else if (this.beslutter != saksbehandler.navIdent) {
+                KanIkkeSetteMeldekortbehandlingPåVent.MåVæreBeslutterForMeldekortet.left()
+            } else {
+                Unit.right()
+            }
+        }
+
+        KLAR_TIL_BEHANDLING,
+        KLAR_TIL_BESLUTNING,
+        GODKJENT,
+        AUTOMATISK_BEHANDLET,
+        AVBRUTT,
+        -> KanIkkeSetteMeldekortbehandlingPåVent.UgyldigStatus(status).left()
     }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/ta/KanIkkeTaMeldekortbehandling.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/ta/KanIkkeTaMeldekortbehandling.kt
@@ -9,6 +9,10 @@ sealed interface KanIkkeTaMeldekortbehandling {
 
     data object HarAlleredeBeslutter : KanIkkeTaMeldekortbehandling
 
+    data object MåVæreSaksbehandler : KanIkkeTaMeldekortbehandling
+
+    data object MåVæreBeslutter : KanIkkeTaMeldekortbehandling
+
     data object BeslutterKanIkkeVæreSammeSomSaksbehandler : KanIkkeTaMeldekortbehandling
 
     data class UgyldigStatus(val status: MeldekortbehandlingStatus) : KanIkkeTaMeldekortbehandling

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/ta/MeldekortbehandlingTaEx.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/meldekortbehandling/ta/MeldekortbehandlingTaEx.kt
@@ -6,8 +6,6 @@ import arrow.core.right
 import no.nav.tiltakspenger.libs.common.Saksbehandler
 import no.nav.tiltakspenger.libs.common.nå
 import no.nav.tiltakspenger.saksbehandling.felles.getOrThrow
-import no.nav.tiltakspenger.saksbehandling.felles.krevBeslutterRolle
-import no.nav.tiltakspenger.saksbehandling.felles.krevSaksbehandlerRolle
 import no.nav.tiltakspenger.saksbehandling.klage.domene.ta.TaKlagebehandlingKommando
 import no.nav.tiltakspenger.saksbehandling.klage.domene.ta.ta
 import no.nav.tiltakspenger.saksbehandling.klage.domene.tilTilknyttetBehandlingsstatus
@@ -26,18 +24,14 @@ fun Meldekortbehandling.taMeldekortbehandling(
     saksbehandler: Saksbehandler,
     clock: Clock,
 ): Either<KanIkkeTaMeldekortbehandling, Meldekortbehandling> {
+    kanTaMeldekortbehandling(saksbehandler).onLeft { return it.left() }
+
     val nå = nå(clock)
     return when (this.status) {
         MeldekortbehandlingStatus.KLAR_TIL_BEHANDLING -> {
             require(this is MeldekortUnderBehandling) {
                 "Forventet MeldekortUnderBehandling for status KLAR_TIL_BEHANDLING, var ${this::class.simpleName}"
             }
-
-            if (this.saksbehandler != null) {
-                return KanIkkeTaMeldekortbehandling.HarAlleredeSaksbehandler.left()
-            }
-
-            krevSaksbehandlerRolle(saksbehandler)
 
             this.copy(
                 saksbehandler = saksbehandler.navIdent,
@@ -62,21 +56,53 @@ fun Meldekortbehandling.taMeldekortbehandling(
                 "Forventet MeldekortbehandlingManuell for status KLAR_TIL_BESLUTNING, var ${this::class.simpleName}"
             }
 
-            if (this.beslutter != null) {
-                return KanIkkeTaMeldekortbehandling.HarAlleredeBeslutter.left()
-            }
-
-            if (this.saksbehandler == saksbehandler.navIdent) {
-                return KanIkkeTaMeldekortbehandling.BeslutterKanIkkeVæreSammeSomSaksbehandler.left()
-            }
-
-            krevBeslutterRolle(saksbehandler)
-
             this.copy(
                 beslutter = saksbehandler.navIdent,
                 status = MeldekortbehandlingStatus.UNDER_BESLUTNING,
                 sistEndret = nå,
             ).right()
+        }
+
+        MeldekortbehandlingStatus.UNDER_BEHANDLING,
+        MeldekortbehandlingStatus.UNDER_BESLUTNING,
+        MeldekortbehandlingStatus.GODKJENT,
+        MeldekortbehandlingStatus.AUTOMATISK_BEHANDLET,
+        MeldekortbehandlingStatus.AVBRUTT,
+        -> KanIkkeTaMeldekortbehandling.UgyldigStatus(this.status).left()
+    }
+}
+
+/**
+ * Avgjør om [saksbehandler] kan ta meldekortbehandlingen.
+ *
+ * Betingelsene speiler hvilke tilstander [taMeldekortbehandling] faktisk håndterer:
+ *  - [MeldekortbehandlingStatus.KLAR_TIL_BEHANDLING]: kan tas av en saksbehandler dersom behandlingen ikke allerede har en saksbehandler.
+ *  - [MeldekortbehandlingStatus.KLAR_TIL_BESLUTNING]: kan tas av en beslutter (som ikke er saksbehandleren) dersom behandlingen ikke allerede har en beslutter.
+ */
+fun Meldekortbehandling.kanTaMeldekortbehandling(
+    saksbehandler: Saksbehandler,
+): Either<KanIkkeTaMeldekortbehandling, Unit> {
+    return when (this.status) {
+        MeldekortbehandlingStatus.KLAR_TIL_BEHANDLING -> {
+            if (this.saksbehandler != null) {
+                KanIkkeTaMeldekortbehandling.HarAlleredeSaksbehandler.left()
+            } else if (!saksbehandler.erSaksbehandler()) {
+                KanIkkeTaMeldekortbehandling.MåVæreSaksbehandler.left()
+            } else {
+                Unit.right()
+            }
+        }
+
+        MeldekortbehandlingStatus.KLAR_TIL_BESLUTNING -> {
+            if (this.beslutter != null) {
+                KanIkkeTaMeldekortbehandling.HarAlleredeBeslutter.left()
+            } else if (this.saksbehandler == saksbehandler.navIdent) {
+                KanIkkeTaMeldekortbehandling.BeslutterKanIkkeVæreSammeSomSaksbehandler.left()
+            } else if (!saksbehandler.erBeslutter()) {
+                KanIkkeTaMeldekortbehandling.MåVæreBeslutter.left()
+            } else {
+                Unit.right()
+            }
         }
 
         MeldekortbehandlingStatus.UNDER_BEHANDLING,

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/GjenopptaMeldekortbehandlingRoute.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/GjenopptaMeldekortbehandlingRoute.kt
@@ -1,9 +1,12 @@
 package no.nav.tiltakspenger.saksbehandling.meldekort.infra.route
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.server.application.ApplicationCall
 import io.ktor.server.auth.principal
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.patch
+import no.nav.tiltakspenger.libs.ktor.common.respond400BadRequest
+import no.nav.tiltakspenger.libs.ktor.common.respond403Forbidden
 import no.nav.tiltakspenger.libs.ktor.common.respondJson
 import no.nav.tiltakspenger.libs.ktor.common.withMeldekortId
 import no.nav.tiltakspenger.libs.ktor.common.withSakId
@@ -16,6 +19,7 @@ import no.nav.tiltakspenger.saksbehandling.felles.autoriserteBrukerroller
 import no.nav.tiltakspenger.saksbehandling.felles.krevSaksbehandlerEllerBeslutterRolle
 import no.nav.tiltakspenger.saksbehandling.infra.route.correlationId
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.gjenoppta.GjenopptaMeldekortbehandlingKommando
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.gjenoppta.KanIkkeGjenopptaMeldekortbehandling
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.GjenopptaMeldekortbehandlingService
 import no.nav.tiltakspenger.saksbehandling.sak.infra.routes.toSakDTO
 import java.time.Clock
@@ -45,20 +49,59 @@ fun Route.gjenopptaMeldekortbehandlingRoute(
                         saksbehandler = saksbehandler,
                         correlationId = correlationId,
                     ),
-                ).also { (sak) ->
-                    auditService.logMedMeldekortId(
-                        meldekortId = meldekortId,
-                        navIdent = saksbehandler.navIdent,
-                        action = AuditLogEvent.Action.UPDATE,
-                        contextMessage = "Meldekortbehandling er blitt gjenopptatt",
-                        correlationId = correlationId,
-                    )
+                ).fold(
+                    { call.respondGjenopptaError(it) },
+                    { (sak) ->
+                        auditService.logMedMeldekortId(
+                            meldekortId = meldekortId,
+                            navIdent = saksbehandler.navIdent,
+                            action = AuditLogEvent.Action.UPDATE,
+                            contextMessage = "Meldekortbehandling er blitt gjenopptatt",
+                            correlationId = correlationId,
+                        )
 
-                    call.respondJson(
-                        value = sak.toSakDTO(saksbehandler, clock),
-                    )
-                }
+                        call.respondJson(
+                            value = sak.toSakDTO(saksbehandler, clock),
+                        )
+                    },
+                )
             }
         }
+    }
+}
+
+private suspend fun ApplicationCall.respondGjenopptaError(
+    feil: KanIkkeGjenopptaMeldekortbehandling,
+) {
+    when (feil) {
+        is KanIkkeGjenopptaMeldekortbehandling.BehandlingenErIkkePåVent -> respond400BadRequest(
+            melding = "Meldekortbehandlingen er ikke satt på vent, og kan derfor ikke gjenopptas.",
+            kode = "behandlingen_er_ikke_paa_vent",
+        )
+
+        is KanIkkeGjenopptaMeldekortbehandling.MåVæreSaksbehandler -> respond403Forbidden(
+            melding = "Du må være saksbehandler for å gjenoppta denne meldekortbehandlingen.",
+            kode = "maa_vaere_saksbehandler",
+        )
+
+        is KanIkkeGjenopptaMeldekortbehandling.MåVæreSaksbehandlerSomEierBehandlingen -> respond403Forbidden(
+            melding = "Du må være saksbehandleren som er tildelt meldekortbehandlingen for å gjenoppta den.",
+            kode = "maa_vaere_saksbehandler_som_eier_behandlingen",
+        )
+
+        is KanIkkeGjenopptaMeldekortbehandling.MåVæreBeslutter -> respond403Forbidden(
+            melding = "Du må være beslutter for å gjenoppta denne meldekortbehandlingen.",
+            kode = "maa_vaere_beslutter",
+        )
+
+        is KanIkkeGjenopptaMeldekortbehandling.BeslutterKanIkkeVæreSammeSomSaksbehandler -> respond400BadRequest(
+            melding = "Beslutter kan ikke være den samme som saksbehandleren på meldekortbehandlingen.",
+            kode = "beslutter_kan_ikke_vaere_samme_som_saksbehandler",
+        )
+
+        is KanIkkeGjenopptaMeldekortbehandling.UgyldigStatus -> respond400BadRequest(
+            melding = "Kan ikke gjenoppta meldekortbehandling med status ${feil.status}.",
+            kode = "ugyldig_status_for_gjenoppta",
+        )
     }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/LeggTilbakeMeldekortbehandlingRoute.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/LeggTilbakeMeldekortbehandlingRoute.kt
@@ -1,9 +1,12 @@
 package no.nav.tiltakspenger.saksbehandling.meldekort.infra.route
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.server.application.ApplicationCall
 import io.ktor.server.auth.principal
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.post
+import no.nav.tiltakspenger.libs.ktor.common.respond400BadRequest
+import no.nav.tiltakspenger.libs.ktor.common.respond403Forbidden
 import no.nav.tiltakspenger.libs.ktor.common.respondJson
 import no.nav.tiltakspenger.libs.ktor.common.withMeldekortId
 import no.nav.tiltakspenger.libs.ktor.common.withSakId
@@ -15,6 +18,7 @@ import no.nav.tiltakspenger.saksbehandling.auth.tilgangskontroll.Tilgangskontrol
 import no.nav.tiltakspenger.saksbehandling.felles.autoriserteBrukerroller
 import no.nav.tiltakspenger.saksbehandling.felles.krevSaksbehandlerEllerBeslutterRolle
 import no.nav.tiltakspenger.saksbehandling.infra.route.correlationId
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.leggTilbake.KanIkkeLeggeTilbakeMeldekortbehandling
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.LeggTilbakeMeldekortbehandlingService
 import no.nav.tiltakspenger.saksbehandling.sak.infra.routes.toSakDTO
 import java.time.Clock
@@ -41,20 +45,54 @@ fun Route.leggTilbakeMeldekortbehandlingRoute(
                     sakId = sakId,
                     meldekortId = meldekortId,
                     saksbehandler = saksbehandler,
-                ).also { (sak) ->
-                    auditService.logMedMeldekortId(
-                        meldekortId = meldekortId,
-                        navIdent = saksbehandler.navIdent,
-                        action = AuditLogEvent.Action.UPDATE,
-                        contextMessage = "Saksbehandler fjernes fra meldekortbehandlingen",
-                        correlationId = correlationId,
-                    )
+                ).fold(
+                    { call.respondLeggTilbakeError(it) },
+                    { (sak) ->
+                        auditService.logMedMeldekortId(
+                            meldekortId = meldekortId,
+                            navIdent = saksbehandler.navIdent,
+                            action = AuditLogEvent.Action.UPDATE,
+                            contextMessage = "Saksbehandler fjernes fra meldekortbehandlingen",
+                            correlationId = correlationId,
+                        )
 
-                    call.respondJson(
-                        value = sak.toSakDTO(saksbehandler = saksbehandler, clock = clock),
-                    )
-                }
+                        call.respondJson(
+                            value = sak.toSakDTO(saksbehandler = saksbehandler, clock = clock),
+                        )
+                    },
+                )
             }
         }
+    }
+}
+
+private suspend fun ApplicationCall.respondLeggTilbakeError(
+    feil: KanIkkeLeggeTilbakeMeldekortbehandling,
+) {
+    when (feil) {
+        is KanIkkeLeggeTilbakeMeldekortbehandling.MåVæreSaksbehandler -> respond403Forbidden(
+            melding = "Du må være saksbehandler for å legge tilbake denne meldekortbehandlingen.",
+            kode = "maa_vaere_saksbehandler",
+        )
+
+        is KanIkkeLeggeTilbakeMeldekortbehandling.MåVæreSaksbehandlerForMeldekortet -> respond403Forbidden(
+            melding = "Du må være saksbehandleren som er tildelt meldekortbehandlingen for å legge den tilbake.",
+            kode = "maa_vaere_saksbehandler_for_meldekortet",
+        )
+
+        is KanIkkeLeggeTilbakeMeldekortbehandling.MåVæreBeslutter -> respond403Forbidden(
+            melding = "Du må være beslutter for å legge tilbake denne meldekortbehandlingen.",
+            kode = "maa_vaere_beslutter",
+        )
+
+        is KanIkkeLeggeTilbakeMeldekortbehandling.MåVæreBeslutterForMeldekortet -> respond403Forbidden(
+            melding = "Du må være beslutteren som er tildelt meldekortbehandlingen for å legge den tilbake.",
+            kode = "maa_vaere_beslutter_for_meldekortet",
+        )
+
+        is KanIkkeLeggeTilbakeMeldekortbehandling.UgyldigStatus -> respond400BadRequest(
+            melding = "Kan ikke legge tilbake meldekortbehandling med status ${feil.status}.",
+            kode = "ugyldig_status_for_legg_tilbake",
+        )
     }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/OpprettMeldekortbehandlingRoute.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/OpprettMeldekortbehandlingRoute.kt
@@ -91,6 +91,7 @@ fun Route.opprettMeldekortbehandlingRoute(
                                     beregninger = sak.meldeperiodeBeregninger,
                                     hentVedtak = { null },
                                     hentTilbakekreving = { null },
+                                    kallendeSaksbehandler = saksbehandler,
                                 ),
                             )
                         } else {

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/OvertaMeldekortbehandlingRoute.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/OvertaMeldekortbehandlingRoute.kt
@@ -110,5 +110,20 @@ internal fun KunneIkkeOvertaMeldekortbehandling.tilStatusOgErrorJson(): Pair<Htt
             "Behandlingen kan ikke være en automatisk behandling",
             "behandling_kan_ikke_være_automatisk",
         )
+
+        KunneIkkeOvertaMeldekortbehandling.MåVæreSaksbehandler -> HttpStatusCode.Forbidden to ErrorJson(
+            "Du må være saksbehandler for å overta denne meldekortbehandlingen",
+            "maa_vaere_saksbehandler",
+        )
+
+        KunneIkkeOvertaMeldekortbehandling.MåVæreBeslutter -> HttpStatusCode.Forbidden to ErrorJson(
+            "Du må være beslutter for å overta denne meldekortbehandlingen",
+            "maa_vaere_beslutter",
+        )
+
+        is KunneIkkeOvertaMeldekortbehandling.UgyldigStatus -> HttpStatusCode.BadRequest to ErrorJson(
+            "Kan ikke overta meldekortbehandling med status ${this.status}",
+            "ugyldig_status_for_overta",
+        )
     }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/SettMeldekortbehandlingPåVentRoute.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/SettMeldekortbehandlingPåVentRoute.kt
@@ -1,6 +1,7 @@
 package no.nav.tiltakspenger.saksbehandling.meldekort.infra.route
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.server.application.ApplicationCall
 import io.ktor.server.auth.principal
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.patch
@@ -8,6 +9,8 @@ import no.nav.tiltakspenger.libs.common.CorrelationId
 import no.nav.tiltakspenger.libs.common.MeldekortId
 import no.nav.tiltakspenger.libs.common.SakId
 import no.nav.tiltakspenger.libs.common.Saksbehandler
+import no.nav.tiltakspenger.libs.ktor.common.respond400BadRequest
+import no.nav.tiltakspenger.libs.ktor.common.respond403Forbidden
 import no.nav.tiltakspenger.libs.ktor.common.respondJson
 import no.nav.tiltakspenger.libs.ktor.common.withBody
 import no.nav.tiltakspenger.libs.ktor.common.withMeldekortId
@@ -20,6 +23,7 @@ import no.nav.tiltakspenger.saksbehandling.auth.tilgangskontroll.Tilgangskontrol
 import no.nav.tiltakspenger.saksbehandling.felles.autoriserteBrukerroller
 import no.nav.tiltakspenger.saksbehandling.felles.krevSaksbehandlerEllerBeslutterRolle
 import no.nav.tiltakspenger.saksbehandling.infra.route.correlationId
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.settPåVent.KanIkkeSetteMeldekortbehandlingPåVent
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.settPåVent.SettMeldekortbehandlingPåVentKommando
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.SettMeldekortbehandlingPåVentService
 import no.nav.tiltakspenger.saksbehandling.sak.infra.routes.toSakDTO
@@ -71,19 +75,58 @@ fun Route.settMeldekortbehandlingPåVentRoute(
                             saksbehandler = saksbehandler,
                             correlationId = correlationId,
                         ),
-                    ).also { (sak, behandling) ->
-                        auditService.logMedMeldekortId(
-                            meldekortId = meldekortId,
-                            navIdent = saksbehandler.navIdent,
-                            action = AuditLogEvent.Action.UPDATE,
-                            contextMessage = "Meldekortbehandling er satt på vent",
-                            correlationId = correlationId,
-                        )
+                    ).fold(
+                        { call.respondSettPåVentError(it) },
+                        { (sak, _) ->
+                            auditService.logMedMeldekortId(
+                                meldekortId = meldekortId,
+                                navIdent = saksbehandler.navIdent,
+                                action = AuditLogEvent.Action.UPDATE,
+                                contextMessage = "Meldekortbehandling er satt på vent",
+                                correlationId = correlationId,
+                            )
 
-                        call.respondJson(value = sak.toSakDTO(saksbehandler, clock))
-                    }
+                            call.respondJson(value = sak.toSakDTO(saksbehandler, clock))
+                        },
+                    )
                 }
             }
         }
+    }
+}
+
+private suspend fun ApplicationCall.respondSettPåVentError(
+    feil: KanIkkeSetteMeldekortbehandlingPåVent,
+) {
+    when (feil) {
+        is KanIkkeSetteMeldekortbehandlingPåVent.BehandlingenErAlleredePåVent -> respond400BadRequest(
+            melding = "Meldekortbehandlingen er allerede satt på vent.",
+            kode = "behandlingen_er_allerede_paa_vent",
+        )
+
+        is KanIkkeSetteMeldekortbehandlingPåVent.MåVæreSaksbehandler -> respond403Forbidden(
+            melding = "Du må være saksbehandler for å sette denne meldekortbehandlingen på vent.",
+            kode = "maa_vaere_saksbehandler",
+        )
+
+        is KanIkkeSetteMeldekortbehandlingPåVent.MåVæreSaksbehandlerForMeldekortet -> respond403Forbidden(
+            melding = "Du må være saksbehandleren som er tildelt meldekortbehandlingen for å sette den på vent.",
+            kode = "maa_vaere_saksbehandler_for_meldekortet",
+        )
+
+        is KanIkkeSetteMeldekortbehandlingPåVent.MåVæreBeslutter -> respond403Forbidden(
+            melding = "Du må være beslutter for å sette denne meldekortbehandlingen på vent.",
+            kode = "maa_vaere_beslutter",
+        )
+
+        is KanIkkeSetteMeldekortbehandlingPåVent.MåVæreBeslutterForMeldekortet -> respond403Forbidden(
+            melding = "Du må være beslutteren som er tildelt meldekortbehandlingen for å sette den på vent.",
+            kode = "maa_vaere_beslutter_for_meldekortet",
+        )
+
+        is KanIkkeSetteMeldekortbehandlingPåVent.UgyldigStatus -> respond400BadRequest(
+            melding = "Kan ikke sette meldekortbehandling med status ${feil.status} på vent.",
+            kode = "ugyldig_status_for_sett_paa_vent",
+        )
     }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/TaMeldekortbehandlingRoute.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/TaMeldekortbehandlingRoute.kt
@@ -5,6 +5,7 @@ import io.ktor.server.auth.principal
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.post
 import no.nav.tiltakspenger.libs.ktor.common.respond400BadRequest
+import no.nav.tiltakspenger.libs.ktor.common.respond403Forbidden
 import no.nav.tiltakspenger.libs.ktor.common.respond404NotFound
 import no.nav.tiltakspenger.libs.ktor.common.respondJson
 import no.nav.tiltakspenger.libs.ktor.common.withMeldekortId
@@ -60,6 +61,16 @@ fun Route.taMeldekortbehandlingRoute(
                             is KanIkkeTaMeldekortbehandling.HarAlleredeBeslutter -> call.respond400BadRequest(
                                 melding = "Meldekortbehandlingen har allerede en beslutter. Bruk overta for å overta behandlingen.",
                                 kode = "behandlingen_har_allerede_beslutter",
+                            )
+
+                            is KanIkkeTaMeldekortbehandling.MåVæreSaksbehandler -> call.respond403Forbidden(
+                                melding = "Du må være saksbehandler for å ta denne meldekortbehandlingen.",
+                                kode = "maa_vaere_saksbehandler",
+                            )
+
+                            is KanIkkeTaMeldekortbehandling.MåVæreBeslutter -> call.respond403Forbidden(
+                                melding = "Du må være beslutter for å ta denne meldekortbehandlingen.",
+                                kode = "maa_vaere_beslutter",
                             )
 
                             is KanIkkeTaMeldekortbehandling.BeslutterKanIkkeVæreSammeSomSaksbehandler -> call.respond400BadRequest(

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/dto/v2/MeldekortbehandlingDTOV2.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/dto/v2/MeldekortbehandlingDTOV2.kt
@@ -22,7 +22,7 @@ import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingManuell
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldeperiodebehandlingMedBeregning
-import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.gyldigeKommandoer
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.finnGyldigeKommandoer
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortvedtak.Meldekortvedtak
 import no.nav.tiltakspenger.saksbehandling.meldekort.infra.route.dto.MeldekortDagDTO
 import no.nav.tiltakspenger.saksbehandling.meldekort.infra.route.dto.MeldekortbehandlingStatusDTO
@@ -122,7 +122,7 @@ fun Meldekortbehandling.tilMeldekortbehandlingDTOV2(
         skalSendeVedtaksbrev = skalSendeVedtaksbrev,
         ventestatus = ventestatus.ventestatusHendelser.tilDto(),
         klagebehandlingId = this.klagebehandling?.id?.toString(),
-        gyldigeKommandoer = this.gyldigeKommandoer(kallendeSaksbehandler).tilDTO(),
+        gyldigeKommandoer = this.finnGyldigeKommandoer(kallendeSaksbehandler).tilDTO(),
     )
 }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/dto/v2/MeldekortbehandlingDTOV2.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/dto/v2/MeldekortbehandlingDTOV2.kt
@@ -1,6 +1,7 @@
 package no.nav.tiltakspenger.saksbehandling.meldekort.infra.route.dto.v2
 
 import no.nav.tiltakspenger.libs.common.MeldekortId
+import no.nav.tiltakspenger.libs.common.Saksbehandler
 import no.nav.tiltakspenger.libs.periode.PeriodeDTO
 import no.nav.tiltakspenger.libs.periode.toDTO
 import no.nav.tiltakspenger.saksbehandling.beregning.MeldeperiodeBeregning
@@ -21,6 +22,7 @@ import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingManuell
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldeperiodebehandlingMedBeregning
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.gyldigeKommandoer
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortvedtak.Meldekortvedtak
 import no.nav.tiltakspenger.saksbehandling.meldekort.infra.route.dto.MeldekortDagDTO
 import no.nav.tiltakspenger.saksbehandling.meldekort.infra.route.dto.MeldekortbehandlingStatusDTO
@@ -28,6 +30,8 @@ import no.nav.tiltakspenger.saksbehandling.meldekort.infra.route.dto.Meldeperiod
 import no.nav.tiltakspenger.saksbehandling.meldekort.infra.route.dto.tilDTO
 import no.nav.tiltakspenger.saksbehandling.meldekort.infra.route.dto.tilMeldekortDagerDTO
 import no.nav.tiltakspenger.saksbehandling.meldekort.infra.route.dto.toStatusDTO
+import no.nav.tiltakspenger.saksbehandling.saksbehandler.SaksbehandlerBehandlingKommandoDTO
+import no.nav.tiltakspenger.saksbehandling.saksbehandler.tilDTO
 import no.nav.tiltakspenger.saksbehandling.tilbakekreving.domene.TilbakekrevingBehandling
 import no.nav.tiltakspenger.saksbehandling.utbetaling.domene.validerKanIverksetteUtbetaling
 import no.nav.tiltakspenger.saksbehandling.utbetaling.infra.http.KanIkkeIverksetteUtbetalingDTO
@@ -67,6 +71,7 @@ data class MeldekortbehandlingDTOV2(
      */
     val ventestatus: List<VentestatusHendelseDTO>,
     val klagebehandlingId: String?,
+    val gyldigeKommandoer: List<SaksbehandlerBehandlingKommandoDTO>,
 )
 
 data class MeldeperiodebehandlingDTO(
@@ -84,6 +89,7 @@ fun Meldekortbehandling.tilMeldekortbehandlingDTOV2(
     beregninger: MeldeperiodeBeregningerVedtatt,
     hentVedtak: (id: MeldekortId) -> Meldekortvedtak?,
     hentTilbakekreving: (id: MeldekortId) -> TilbakekrevingBehandling?,
+    kallendeSaksbehandler: Saksbehandler,
 ): MeldekortbehandlingDTOV2 {
     val vedtak: Meldekortvedtak? = hentVedtak(id)
 
@@ -94,7 +100,7 @@ fun Meldekortbehandling.tilMeldekortbehandlingDTOV2(
     return MeldekortbehandlingDTOV2(
         id = id.toString(),
         sakId = sakId.toString(),
-        saksbehandler = saksbehandler,
+        saksbehandler = this.saksbehandler,
         beslutter = beslutter,
         opprettet = opprettet,
         godkjentTidspunkt = vedtak?.opprettet ?: iverksattTidspunkt,
@@ -116,6 +122,7 @@ fun Meldekortbehandling.tilMeldekortbehandlingDTOV2(
         skalSendeVedtaksbrev = skalSendeVedtaksbrev,
         ventestatus = ventestatus.ventestatusHendelser.tilDto(),
         klagebehandlingId = this.klagebehandling?.id?.toString(),
+        gyldigeKommandoer = this.gyldigeKommandoer(kallendeSaksbehandler).tilDTO(),
     )
 }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/GjenopptaMeldekortbehandlingService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/GjenopptaMeldekortbehandlingService.kt
@@ -1,9 +1,11 @@
 package no.nav.tiltakspenger.saksbehandling.meldekort.service
 
+import arrow.core.Either
 import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.tiltakspenger.saksbehandling.behandling.service.sak.SakService
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.Meldekortbehandling
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.gjenoppta.GjenopptaMeldekortbehandlingKommando
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.gjenoppta.KanIkkeGjenopptaMeldekortbehandling
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.gjenoppta.gjenoppta
 import no.nav.tiltakspenger.saksbehandling.meldekort.ports.MeldekortbehandlingRepo
 import no.nav.tiltakspenger.saksbehandling.sak.Sak
@@ -18,16 +20,14 @@ class GjenopptaMeldekortbehandlingService(
 
     fun gjenoppta(
         kommando: GjenopptaMeldekortbehandlingKommando,
-    ): Pair<Sak, Meldekortbehandling> {
+    ): Either<KanIkkeGjenopptaMeldekortbehandling, Pair<Sak, Meldekortbehandling>> {
         val sak = sakService.hentForSakId(kommando.sakId)
         val meldekortbehandling = sak.hentMeldekortbehandling(kommando.meldekortId)!!
 
-        val oppdatertMeldekortbehandling = meldekortbehandling.gjenoppta(kommando, clock)
-            .also {
-                meldekortbehandlingRepo.oppdater(it)
-                logger.info { "Meldekortbehandling med id ${it.id} gjenopptatt. Saksbehandler: ${kommando.saksbehandler.navIdent}" }
-            }
-
-        return sak.oppdaterMeldekortbehandling(oppdatertMeldekortbehandling) to oppdatertMeldekortbehandling
+        return meldekortbehandling.gjenoppta(kommando, clock).map { oppdatertMeldekortbehandling ->
+            meldekortbehandlingRepo.oppdater(oppdatertMeldekortbehandling)
+            logger.info { "Meldekortbehandling med id ${oppdatertMeldekortbehandling.id} gjenopptatt. Saksbehandler: ${kommando.saksbehandler.navIdent}" }
+            sak.oppdaterMeldekortbehandling(oppdatertMeldekortbehandling) to oppdatertMeldekortbehandling
+        }
     }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/LeggTilbakeMeldekortbehandlingService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/LeggTilbakeMeldekortbehandlingService.kt
@@ -1,5 +1,6 @@
 package no.nav.tiltakspenger.saksbehandling.meldekort.service
 
+import arrow.core.Either
 import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.tiltakspenger.libs.common.MeldekortId
 import no.nav.tiltakspenger.libs.common.SakId
@@ -7,6 +8,8 @@ import no.nav.tiltakspenger.libs.common.Saksbehandler
 import no.nav.tiltakspenger.saksbehandling.behandling.service.sak.SakService
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.Meldekortbehandling
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.leggTilbake.KanIkkeLeggeTilbakeMeldekortbehandling
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.leggTilbake.leggTilbakeMeldekortbehandling
 import no.nav.tiltakspenger.saksbehandling.meldekort.ports.MeldekortbehandlingRepo
 import no.nav.tiltakspenger.saksbehandling.sak.Sak
 import java.time.Clock
@@ -22,10 +25,10 @@ class LeggTilbakeMeldekortbehandlingService(
         sakId: SakId,
         meldekortId: MeldekortId,
         saksbehandler: Saksbehandler,
-    ): Pair<Sak, Meldekortbehandling> {
+    ): Either<KanIkkeLeggeTilbakeMeldekortbehandling, Pair<Sak, Meldekortbehandling>> {
         val sak: Sak = sakService.hentForSakId(sakId)
         val meldekortbehandling: Meldekortbehandling = sak.hentMeldekortbehandling(meldekortId)!!
-        return meldekortbehandling.leggTilbakeMeldekortbehandling(saksbehandler, clock).let {
+        return meldekortbehandling.leggTilbakeMeldekortbehandling(saksbehandler, clock).map {
             when (it.status) {
                 MeldekortbehandlingStatus.KLAR_TIL_BEHANDLING -> meldekortbehandlingRepo.leggTilbakeBehandlingSaksbehandler(
                     it,

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/OvertaMeldekortbehandlingService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/OvertaMeldekortbehandlingService.kt
@@ -6,6 +6,7 @@ import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.overta.KunneIkkeOvertaMeldekortbehandling
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.overta.OvertaMeldekortbehandlingKommando
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.overta.overta
 import no.nav.tiltakspenger.saksbehandling.meldekort.ports.MeldekortbehandlingRepo
 import no.nav.tiltakspenger.saksbehandling.sak.Sak
 import java.time.Clock

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/SettMeldekortbehandlingPåVentService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/SettMeldekortbehandlingPåVentService.kt
@@ -1,8 +1,10 @@
 package no.nav.tiltakspenger.saksbehandling.meldekort.service
 
+import arrow.core.Either
 import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.tiltakspenger.saksbehandling.behandling.service.sak.SakService
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.Meldekortbehandling
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.settPåVent.KanIkkeSetteMeldekortbehandlingPåVent
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.settPåVent.SettMeldekortbehandlingPåVentKommando
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.settPåVent.settPåVent
 import no.nav.tiltakspenger.saksbehandling.meldekort.ports.MeldekortbehandlingRepo
@@ -18,16 +20,14 @@ class SettMeldekortbehandlingPåVentService(
 
     fun settPåVent(
         kommando: SettMeldekortbehandlingPåVentKommando,
-    ): Pair<Sak, Meldekortbehandling> {
+    ): Either<KanIkkeSetteMeldekortbehandlingPåVent, Pair<Sak, Meldekortbehandling>> {
         val sak = sakService.hentForSakId(kommando.sakId)
         val meldekortbehandling = sak.hentMeldekortbehandling(kommando.meldekortId)!!
 
-        val oppdatertMeldekortbehandling = meldekortbehandling.settPåVent(kommando, clock)
-            .also {
-                meldekortbehandlingRepo.oppdater(it)
-                logger.info { "Meldekortbehandling med id ${it.id} satt på vent. Saksbehandler: ${kommando.saksbehandler.navIdent}" }
-            }
-
-        return sak.oppdaterMeldekortbehandling(oppdatertMeldekortbehandling) to oppdatertMeldekortbehandling
+        return meldekortbehandling.settPåVent(kommando, clock).map { oppdatertMeldekortbehandling ->
+            meldekortbehandlingRepo.oppdater(oppdatertMeldekortbehandling)
+            logger.info { "Meldekortbehandling med id ${oppdatertMeldekortbehandling.id} satt på vent. Saksbehandler: ${kommando.saksbehandler.navIdent}" }
+            sak.oppdaterMeldekortbehandling(oppdatertMeldekortbehandling) to oppdatertMeldekortbehandling
+        }
     }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/sak/infra/routes/SakDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/sak/infra/routes/SakDTO.kt
@@ -85,6 +85,7 @@ fun Sak.toSakDTO(saksbehandler: Saksbehandler, clock: Clock) = SakDTO(
             beregninger = this.meldeperiodeBeregninger,
             hentVedtak = this.meldekortvedtaksliste::hentForMeldekortbehandling,
             hentTilbakekreving = this::hentTilbakekrevingForMeldekortbehandling,
+            kallendeSaksbehandler = saksbehandler,
         )
     },
     åpenMeldekortbehandlingId = meldekortbehandlinger.åpenMeldekortbehandling?.id?.toString(),

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/saksbehandler/SaksbehandlerBehandlingKommando.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/saksbehandler/SaksbehandlerBehandlingKommando.kt
@@ -14,7 +14,7 @@ enum class SaksbehandlerBehandlingKommando {
     LeggTilbakeBeslutter,
     SettPåVent,
     Gjenoppta,
-    Avslutt,
+    Avbryt,
     ;
 
     fun tilDTO(): SaksbehandlerBehandlingKommandoDTO {
@@ -27,7 +27,7 @@ enum class SaksbehandlerBehandlingKommando {
             LeggTilbakeBeslutter -> SaksbehandlerBehandlingKommandoDTO.LeggTilbakeBeslutter
             SettPåVent -> SaksbehandlerBehandlingKommandoDTO.SettPåVent
             Gjenoppta -> SaksbehandlerBehandlingKommandoDTO.Gjenoppta
-            Avslutt -> SaksbehandlerBehandlingKommandoDTO.Avslutt
+            Avbryt -> SaksbehandlerBehandlingKommandoDTO.Avbryt
         }
     }
 }
@@ -41,7 +41,7 @@ enum class SaksbehandlerBehandlingKommandoDTO {
     LeggTilbakeBeslutter,
     SettPåVent,
     Gjenoppta,
-    Avslutt,
+    Avbryt,
 }
 
 fun List<SaksbehandlerBehandlingKommando>.tilDTO(): List<SaksbehandlerBehandlingKommandoDTO> {

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/benk/infra/repo/BenkOversiktPostgresRepoTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/benk/infra/repo/BenkOversiktPostgresRepoTest.kt
@@ -11,6 +11,7 @@ import no.nav.tiltakspenger.libs.common.Saksbehandlerroller
 import no.nav.tiltakspenger.libs.common.TikkendeKlokke
 import no.nav.tiltakspenger.libs.common.fixedClock
 import no.nav.tiltakspenger.libs.common.fixedClockAt
+import no.nav.tiltakspenger.libs.common.getOrFail
 import no.nav.tiltakspenger.libs.common.nå
 import no.nav.tiltakspenger.libs.dato.august
 import no.nav.tiltakspenger.libs.dato.februar
@@ -473,7 +474,7 @@ class BenkOversiktPostgresRepoTest {
                     correlationId = CorrelationId.generate(),
                 ),
                 clock = testDataHelper.clock,
-            )
+            ).getOrFail()
             testDataHelper.meldekortRepo.oppdater(meldekortbehandlingPåVent)
 
             val (actual, totalAntall, totalAntallUfiltrert) = testDataHelper.benkOversiktRepo.hentÅpneBehandlinger(

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortbehandlingSettPåVentTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortbehandlingSettPåVentTest.kt
@@ -1,6 +1,5 @@
 package no.nav.tiltakspenger.saksbehandling.meldekort.domene
 
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import no.nav.tiltakspenger.libs.common.CorrelationId
@@ -18,6 +17,7 @@ import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.gjenoppta.GjenopptaMeldekortbehandlingKommando
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.gjenoppta.KanIkkeGjenopptaMeldekortbehandling
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.gjenoppta.gjenoppta
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.settPåVent.KanIkkeSetteMeldekortbehandlingPåVent
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.settPåVent.SettMeldekortbehandlingPåVentKommando
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.settPåVent.settPåVent
 import no.nav.tiltakspenger.saksbehandling.objectmothers.ObjectMother
@@ -42,7 +42,7 @@ class MeldekortbehandlingSettPåVentTest {
                 frist = frist,
             ),
             clock = fixedClock,
-        )
+        ).getOrFail()
 
         oppdatert.shouldBeInstanceOf<MeldekortUnderBehandling>()
         oppdatert.status shouldBe MeldekortbehandlingStatus.KLAR_TIL_BEHANDLING
@@ -68,7 +68,7 @@ class MeldekortbehandlingSettPåVentTest {
                 saksbehandler = beslutter,
             ),
             clock = fixedClock,
-        )
+        ).getOrFail()
 
         oppdatert.shouldBeInstanceOf<MeldekortbehandlingManuell>()
         oppdatert.status shouldBe MeldekortbehandlingStatus.KLAR_TIL_BESLUTNING
@@ -85,18 +85,16 @@ class MeldekortbehandlingSettPåVentTest {
             saksbehandler = saksbehandler.navIdent,
         )
 
-        val exception = shouldThrow<IllegalStateException> {
-            meldekortbehandling.settPåVent(
-                kommando = settPåVentKommando(
-                    sakId = meldekortbehandling.sakId,
-                    meldekortId = meldekortbehandling.id,
-                    saksbehandler = saksbehandler,
-                ),
-                clock = fixedClock,
-            )
-        }
+        val feil = meldekortbehandling.settPåVent(
+            kommando = settPåVentKommando(
+                sakId = meldekortbehandling.sakId,
+                meldekortId = meldekortbehandling.id,
+                saksbehandler = saksbehandler,
+            ),
+            clock = fixedClock,
+        ).leftOrNull()
 
-        exception.message shouldBe "Kan ikke sette meldekortbehandling på vent som har status AVBRUTT"
+        feil shouldBe KanIkkeSetteMeldekortbehandlingPåVent.UgyldigStatus(MeldekortbehandlingStatus.AVBRUTT)
     }
 
     @Test
@@ -104,18 +102,16 @@ class MeldekortbehandlingSettPåVentTest {
         val saksbehandler = ObjectMother.saksbehandler()
         val meldekortbehandling = ObjectMother.meldekortBehandletAutomatisk()
 
-        val exception = shouldThrow<IllegalStateException> {
-            meldekortbehandling.settPåVent(
-                kommando = settPåVentKommando(
-                    sakId = meldekortbehandling.sakId,
-                    meldekortId = meldekortbehandling.id,
-                    saksbehandler = saksbehandler,
-                ),
-                clock = fixedClock,
-            )
-        }
+        val feil = meldekortbehandling.settPåVent(
+            kommando = settPåVentKommando(
+                sakId = meldekortbehandling.sakId,
+                meldekortId = meldekortbehandling.id,
+                saksbehandler = saksbehandler,
+            ),
+            clock = fixedClock,
+        ).leftOrNull()
 
-        exception.message shouldBe "Kan ikke sette meldekortbehandling på vent som har status AUTOMATISK_BEHANDLET"
+        feil shouldBe KanIkkeSetteMeldekortbehandlingPåVent.UgyldigStatus(MeldekortbehandlingStatus.AUTOMATISK_BEHANDLET)
     }
 
     @Test
@@ -133,7 +129,7 @@ class MeldekortbehandlingSettPåVentTest {
                 saksbehandler = saksbehandler,
             ),
             clock = clock,
-        )
+        ).getOrFail()
 
         val oppdatert = meldekortbehandling.gjenoppta(
             kommando = GjenopptaMeldekortbehandlingKommando(
@@ -229,7 +225,7 @@ class MeldekortbehandlingSettPåVentTest {
                 saksbehandler = beslutter,
             ),
             clock = clock,
-        )
+        ).getOrFail()
 
         val oppdatert = meldekortbehandling.gjenoppta(
             kommando = gjenopptaMeldekortbehandlingKommando(

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortbehandlingSettPåVentTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortbehandlingSettPåVentTest.kt
@@ -9,12 +9,14 @@ import no.nav.tiltakspenger.libs.common.SakId
 import no.nav.tiltakspenger.libs.common.Saksbehandler
 import no.nav.tiltakspenger.libs.common.TikkendeKlokke
 import no.nav.tiltakspenger.libs.common.fixedClock
+import no.nav.tiltakspenger.libs.common.getOrFail
 import no.nav.tiltakspenger.libs.common.nå
 import no.nav.tiltakspenger.saksbehandling.felles.Ventestatus
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortUnderBehandling
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingManuell
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.MeldekortbehandlingStatus
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.gjenoppta.GjenopptaMeldekortbehandlingKommando
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.gjenoppta.KanIkkeGjenopptaMeldekortbehandling
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.gjenoppta.gjenoppta
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.settPåVent.SettMeldekortbehandlingPåVentKommando
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.meldekortbehandling.settPåVent.settPåVent
@@ -141,7 +143,7 @@ class MeldekortbehandlingSettPåVentTest {
                 correlationId = CorrelationId.generate(),
             ),
             clock = clock,
-        )
+        ).getOrFail()
 
         oppdatert.shouldBeInstanceOf<MeldekortUnderBehandling>()
         oppdatert.status shouldBe MeldekortbehandlingStatus.UNDER_BEHANDLING
@@ -173,7 +175,7 @@ class MeldekortbehandlingSettPåVentTest {
                 correlationId = CorrelationId.generate(),
             ),
             clock = clock,
-        )
+        ).getOrFail()
 
         oppdatert.shouldBeInstanceOf<MeldekortUnderBehandling>()
         oppdatert.status shouldBe MeldekortbehandlingStatus.UNDER_BEHANDLING
@@ -198,19 +200,17 @@ class MeldekortbehandlingSettPåVentTest {
             ),
         )
 
-        val exception = shouldThrow<IllegalArgumentException> {
-            meldekortbehandling.gjenoppta(
-                kommando = GjenopptaMeldekortbehandlingKommando(
-                    sakId = meldekortbehandling.sakId,
-                    meldekortId = meldekortbehandling.id,
-                    saksbehandler = annenSaksbehandler,
-                    correlationId = CorrelationId.generate(),
-                ),
-                clock = clock,
-            )
-        }
+        val feil = meldekortbehandling.gjenoppta(
+            kommando = GjenopptaMeldekortbehandlingKommando(
+                sakId = meldekortbehandling.sakId,
+                meldekortId = meldekortbehandling.id,
+                saksbehandler = annenSaksbehandler,
+                correlationId = CorrelationId.generate(),
+            ),
+            clock = clock,
+        ).leftOrNull()
 
-        exception.message shouldBe "Du må være saksbehandler på meldekortbehandlingen for å kunne gjenoppta den."
+        feil shouldBe KanIkkeGjenopptaMeldekortbehandling.MåVæreSaksbehandlerSomEierBehandlingen
     }
 
     @Test
@@ -238,7 +238,7 @@ class MeldekortbehandlingSettPåVentTest {
                 saksbehandler = beslutter,
             ),
             clock = clock,
-        )
+        ).getOrFail()
 
         oppdatert.shouldBeInstanceOf<MeldekortbehandlingManuell>()
         oppdatert.status shouldBe MeldekortbehandlingStatus.UNDER_BESLUTNING
@@ -263,18 +263,16 @@ class MeldekortbehandlingSettPåVentTest {
             ),
         )
 
-        val exception = shouldThrow<IllegalStateException> {
-            meldekortbehandlingPåVent.gjenoppta(
-                kommando = gjenopptaMeldekortbehandlingKommando(
-                    sakId = meldekortbehandlingPåVent.sakId,
-                    meldekortId = meldekortbehandlingPåVent.id,
-                    saksbehandler = saksbehandler,
-                ),
-                clock = clock,
-            )
-        }
+        val feil = meldekortbehandlingPåVent.gjenoppta(
+            kommando = gjenopptaMeldekortbehandlingKommando(
+                sakId = meldekortbehandlingPåVent.sakId,
+                meldekortId = meldekortbehandlingPåVent.id,
+                saksbehandler = saksbehandler,
+            ),
+            clock = clock,
+        ).leftOrNull()
 
-        exception.message shouldBe "Kan ikke gjenoppta meldekortbehandling som har status AVBRUTT"
+        feil shouldBe KanIkkeGjenopptaMeldekortbehandling.UgyldigStatus(MeldekortbehandlingStatus.AVBRUTT)
     }
 
     @Test
@@ -283,18 +281,16 @@ class MeldekortbehandlingSettPåVentTest {
         val saksbehandler = ObjectMother.saksbehandler()
         val meldekortbehandling = ObjectMother.meldekortBehandletAutomatisk()
 
-        val exception = shouldThrow<IllegalArgumentException> {
-            meldekortbehandling.gjenoppta(
-                kommando = gjenopptaMeldekortbehandlingKommando(
-                    sakId = meldekortbehandling.sakId,
-                    meldekortId = meldekortbehandling.id,
-                    saksbehandler = saksbehandler,
-                ),
-                clock = clock,
-            )
-        }
+        val feil = meldekortbehandling.gjenoppta(
+            kommando = gjenopptaMeldekortbehandlingKommando(
+                sakId = meldekortbehandling.sakId,
+                meldekortId = meldekortbehandling.id,
+                saksbehandler = saksbehandler,
+            ),
+            clock = clock,
+        ).leftOrNull()
 
-        exception.message shouldBe "Meldekortbehandling med id ${meldekortbehandling.id} er ikke satt på vent"
+        feil shouldBe KanIkkeGjenopptaMeldekortbehandling.BehandlingenErIkkePåVent
     }
 
     private fun settPåVentKommando(


### PR DESCRIPTION
Setter nå gyldige kommandoer som en saksbehandler kan utføre på en meldekortbehandling, med samme valideringsregler som i domenekoden. Da slipper vi å duplisere logikken i frontend lengre :tada: 