### PR TITLE
ci: pin nais/docker-build-push til SHA (# v0)

### DIFF
--- a/.github/workflows/.test-and-build.yml
+++ b/.github/workflows/.test-and-build.yml
@@ -41,7 +41,7 @@ jobs:
         run: ./gradlew build installDist --configuration-cache
 
       - name: Build and push docker image
-        uses: nais/docker-build-push@v0
+        uses: nais/docker-build-push@31c3a7321909bcb20799fdf46153fec721fd9512 # v0
         id: docker-push
         if: inputs.buildImage == true
         with:


### PR DESCRIPTION
## Hva
Pinner `nais/docker-build-push` fra det bevegelige `@v0`-taggen til en immutable SHA-referanse med `# v0`-kommentar:

```yaml
uses: nais/docker-build-push@31c3a7321909bcb20799fdf46153fec721fd9512 # v0
```

## Hvorfor
- `v0` er en **major-tag som overskrives** ved hver release → ikke immutable/sporbar.
- SHA-pinning gir en fast, verifiserbar action-referanse (supply chain / SLSA best practice, jf. [nais/docker-build-push](https://github.com/nais/docker-build-push)).
- **Dependabot** leser `# v0`-kommentaren og bumper SHA-en videre automatisk når `v0` flyttes — dette repoet har allerede `github-actions`-ecosystem i `dependabot.yml`, så oppdateringer fortsetter som før.

## Kontekst
Ingen av tpts-repoene bygger `${image}@${digest}` manuelt, så den nylige canonical-imageref-endringen i docker-build-push påvirker oss ikke. Denne PR-en handler kun om å pinne selve action-versjonen.

Første av 13 tpts-repo — brukes som mal for resten.