### PR TITLE
ci: lenke til versjonsoversikt over docker-build-push-pin

### DIFF
--- a/.github/workflows/.test-and-build.yml
+++ b/.github/workflows/.test-and-build.yml
@@ -42,6 +42,7 @@ jobs:
 
       - name: Build and push docker image
         # Versjonsoversikt (tag -> SHA): https://github.com/nais/docker-build-push/tags
+        # Denne SHA-en: https://github.com/nais/docker-build-push/commit/31c3a7321909bcb20799fdf46153fec721fd9512
         uses: nais/docker-build-push@31c3a7321909bcb20799fdf46153fec721fd9512 # v0
         id: docker-push
         if: inputs.buildImage == true

--- a/.github/workflows/.test-and-build.yml
+++ b/.github/workflows/.test-and-build.yml
@@ -41,6 +41,7 @@ jobs:
         run: ./gradlew build installDist --configuration-cache
 
       - name: Build and push docker image
+        # Versjonsoversikt (tag -> SHA): https://github.com/nais/docker-build-push/tags
         uses: nais/docker-build-push@31c3a7321909bcb20799fdf46153fec721fd9512 # v0
         id: docker-push
         if: inputs.buildImage == true


### PR DESCRIPTION
## Hva
Legger til kommentarer med lenker til versjonsoversikten og den faktiske commit-en rett over den SHA-pinnede `nais/docker-build-push` (pinnet i #1651):

```yaml
# Versjonsoversikt (tag -> SHA): https://github.com/nais/docker-build-push/tags
# Denne SHA-en: https://github.com/nais/docker-build-push/commit/31c3a7321909bcb20799fdf46153fec721fd9512
uses: nais/docker-build-push@31c3a7321909bcb20799fdf46153fec721fd9512 # v0
```

## Hvorfor
Gjør det lett for utviklere å slå opp hvilken versjon en pinnet SHA tilsvarer. Siden taggen alltid er `v0`, peker vi også direkte på commit-en SHA-en er pinnet til, så man ser den faktiske releasen. Samme kommentarer er lagt til i de øvrige tpts-repoene i samme utrulling.